### PR TITLE
LPE 705

### DIFF
--- a/app/uk/gov/hmrc/membersprotectionsenhancements/config/AppConfig.scala
+++ b/app/uk/gov/hmrc/membersprotectionsenhancements/config/AppConfig.scala
@@ -26,9 +26,12 @@ class AppConfig @Inject() (configuration: Configuration) {
 
   val appName: String = loadConfig("appName")
 
-  lazy val npsBase: String = configuration.get[Service]("microservice.services.nps")
+  private lazy val npsBase: String = configuration.get[Service]("microservice.services.nps")
 
-  // lazy val matchUrl: String = loadConfig("urls.match")
+  private lazy val npsContext: String = loadConfig("urls.npsContext")
+  lazy val matchUrl: String = npsBase + npsContext + s"/${loadConfig("urls.match")}"
+  lazy val retrieveUrl: String = npsBase + npsContext + s"/${loadConfig("urls.retrieve")}"
 
-  lazy val retrieveUrl: String = s"$npsBase/${loadConfig("urls.retrieve")}"
+  lazy val matchPersonGovUkOriginatorId: String = loadConfig("govUkOriginatorId.matchPerson")
+  lazy val retrieveMpeGovUkOriginatorId: String = loadConfig("govUkOriginatorId.retrieveMpe")
 }

--- a/app/uk/gov/hmrc/membersprotectionsenhancements/connectors/NpsConnector.scala
+++ b/app/uk/gov/hmrc/membersprotectionsenhancements/connectors/NpsConnector.scala
@@ -16,55 +16,86 @@
 
 package uk.gov.hmrc.membersprotectionsenhancements.connectors
 
-import play.api.libs.json.{JsError, JsResultException, JsSuccess}
-import play.shaded.ahc.io.netty.handler.codec.http.HttpMethod
+import cats.data.EitherT
+import play.api.libs.json.Json
 import uk.gov.hmrc.membersprotectionsenhancements.config.AppConfig
 import uk.gov.hmrc.http.client.HttpClientV2
-import uk.gov.hmrc.membersprotectionsenhancements.models.response.ProtectionRecordDetails
+import uk.gov.hmrc.membersprotectionsenhancements.models.response.{MatchPersonResponse, ProtectionRecordDetails}
 import uk.gov.hmrc.membersprotectionsenhancements.utils.HttpResponseHelper
 import uk.gov.hmrc.membersprotectionsenhancements.models.errors.MpeError
-import play.api.http.Status.OK
 import uk.gov.hmrc.http._
+import uk.gov.hmrc.membersprotectionsenhancements.controllers.requests.PensionSchemeMemberRequest
+import uk.gov.hmrc.membersprotectionsenhancements.controllers.requests.PensionSchemeMemberRequest.matchPersonWrites
+import uk.gov.hmrc.membersprotectionsenhancements.utils.HeaderKey.{correlationIdKey, govUkOriginatorIdKey}
 
-import scala.concurrent.{ExecutionContext, Future}
-
+import scala.concurrent.ExecutionContext
 import javax.inject.{Inject, Singleton}
 import java.net.URI
 
 @Singleton
 class NpsConnector @Inject() (val config: AppConfig, val http: HttpClientV2) extends HttpResponseHelper {
+  protected val classLoggingContext: String = "NpsConnector"
 
-//  def search()(implicit hc: HeaderCarrier, ec: ExecutionContext): Future[HttpResponse] = {
-//
-//    //    val searchUrl = s"${config.npsBase}/${config.matchUrl}"
-//    //    http
-//    //      .post(URI.create(searchUrl).toURL)
-//    //      .withBody(Json.toJson(nino))
-//    //      .execute[HttpResponse]
-//
-//    Future.successful(HttpResponse(Status.OK))
-//  }
+  def matchPerson(request: PensionSchemeMemberRequest)
+                 (implicit hc: HeaderCarrier, ec: ExecutionContext): ConnectorResult[MatchPersonResponse] = {
+    val methodLoggingContext: String = "matchPerson"
+    val fullContext: String = s"[$classLoggingContext][$methodLoggingContext]"
+    val matchIndividualAccountUrl: String = config.matchUrl
 
-  def retrieve(
-    nino: String,
-    psaCheckRef: String
-  )(implicit hc: HeaderCarrier, ec: ExecutionContext): Future[Either[MpeError, ProtectionRecordDetails]] = {
+    logger.info(s"$fullContext - Received request to check for a matching individual")
+
+    EitherT(
+      http
+        .post(URI.create(matchIndividualAccountUrl).toURL)
+        .withBody(Json.toJson(request)(matchPersonWrites))
+        .setHeader(
+          (correlationIdKey, "TODO"), //TODO: Populate with an actual correlation ID
+          (govUkOriginatorIdKey, config.matchPersonGovUkOriginatorId)
+        )
+        .execute[Either[MpeError, MatchPersonResponse]]
+    ).bimap(
+      err => {
+        logger.warn(
+          s"$fullContext - Request to check for a matching individual failed with error code: ${err.code}"
+        )
+        err
+      },
+      resp => {
+        logger.info(s"$fullContext - Request to check for a matching individual completed successfully")
+        resp
+      }
+    )
+  }
+
+
+  def retrieveMpe(nino: String, psaCheckRef: String)
+                 (implicit hc: HeaderCarrier, ec: ExecutionContext): ConnectorResult[ProtectionRecordDetails] = {
+    val methodLoggingContext: String = "retrieve"
+    val fullContext: String = s"[$classLoggingContext][$methodLoggingContext]"
 
     val retrieveUrl = s"${config.retrieveUrl}/$nino/admin-reference/$psaCheckRef/lookup"
-    http
-      .get(URI.create(retrieveUrl).toURL)
-      .execute[HttpResponse]
-      .map { response =>
-        response.status match {
-          case OK =>
-            response.json.validate[ProtectionRecordDetails] match {
-              case JsSuccess(value, _) => Right(value)
-              case JsError(errors) => throw JsResultException(errors)
-            }
-          case _ =>
-            logger.error(response.body)
-            Left(handleErrorResponse(HttpMethod.GET.toString, retrieveUrl)(response))
-        }
+
+    logger.info(s"$fullContext - Received request to retrieve member's protections and enhancements")
+
+    EitherT(
+      http
+        .get(URI.create(retrieveUrl).toURL)
+        .setHeader(
+          (correlationIdKey, "TODO"), //TODO: Populate with an actual correlation ID
+          (govUkOriginatorIdKey, config.retrieveMpeGovUkOriginatorId)
+        )
+        .execute[Either[MpeError, ProtectionRecordDetails]]
+    ).bimap(
+      err => {
+        logger.warn(
+          s"$fullContext - Request to retrieve protections and enhancements failed with error code: ${err.code}"
+        )
+        err
+      },
+      resp => {
+        logger.info(s"$fullContext - Request to retrieve protections and enhancements completed successfully")
+        resp
       }
+    )
   }
 }

--- a/app/uk/gov/hmrc/membersprotectionsenhancements/connectors/NpsConnector.scala
+++ b/app/uk/gov/hmrc/membersprotectionsenhancements/connectors/NpsConnector.scala
@@ -16,19 +16,20 @@
 
 package uk.gov.hmrc.membersprotectionsenhancements.connectors
 
+import uk.gov.hmrc.membersprotectionsenhancements.controllers.requests.PensionSchemeMemberRequest.matchPersonWrites
 import cats.data.EitherT
+import uk.gov.hmrc.membersprotectionsenhancements.utils.HeaderKey.{correlationIdKey, govUkOriginatorIdKey}
 import play.api.libs.json.Json
+import uk.gov.hmrc.http._
+import uk.gov.hmrc.membersprotectionsenhancements.controllers.requests.PensionSchemeMemberRequest
 import uk.gov.hmrc.membersprotectionsenhancements.config.AppConfig
 import uk.gov.hmrc.http.client.HttpClientV2
 import uk.gov.hmrc.membersprotectionsenhancements.models.response.{MatchPersonResponse, ProtectionRecordDetails}
 import uk.gov.hmrc.membersprotectionsenhancements.utils.HttpResponseHelper
 import uk.gov.hmrc.membersprotectionsenhancements.models.errors.{MatchPerson, MpeError, RetrieveMpe}
-import uk.gov.hmrc.http._
-import uk.gov.hmrc.membersprotectionsenhancements.controllers.requests.PensionSchemeMemberRequest
-import uk.gov.hmrc.membersprotectionsenhancements.controllers.requests.PensionSchemeMemberRequest.matchPersonWrites
-import uk.gov.hmrc.membersprotectionsenhancements.utils.HeaderKey.{correlationIdKey, govUkOriginatorIdKey}
 
 import scala.concurrent.ExecutionContext
+
 import javax.inject.{Inject, Singleton}
 import java.net.URI
 
@@ -49,7 +50,7 @@ class NpsConnector @Inject() (val config: AppConfig, val http: HttpClientV2) ext
         .post(URI.create(matchIndividualAccountUrl).toURL)
         .withBody(Json.toJson(request)(matchPersonWrites))
         .setHeader(
-          (correlationIdKey, "TODO"), //TODO: Populate with an actual correlation ID
+          (correlationIdKey, "TODO"), // TODO: Populate with an actual correlation ID
           (govUkOriginatorIdKey, config.matchPersonGovUkOriginatorId)
         )
         .execute[Either[MpeError, MatchPersonResponse]]
@@ -67,7 +68,6 @@ class NpsConnector @Inject() (val config: AppConfig, val http: HttpClientV2) ext
     )
   }
 
-
   def retrieveMpe(nino: String, psaCheckRef: String)
                  (implicit hc: HeaderCarrier, ec: ExecutionContext): ConnectorResult[ProtectionRecordDetails] = {
     val methodLoggingContext: String = "retrieve"
@@ -81,7 +81,7 @@ class NpsConnector @Inject() (val config: AppConfig, val http: HttpClientV2) ext
       http
         .get(URI.create(retrieveUrl).toURL)
         .setHeader(
-          (correlationIdKey, "TODO"), //TODO: Populate with an actual correlation ID
+          (correlationIdKey, "TODO"), // TODO: Populate with an actual correlation ID
           (govUkOriginatorIdKey, config.retrieveMpeGovUkOriginatorId)
         )
         .execute[Either[MpeError, ProtectionRecordDetails]]

--- a/app/uk/gov/hmrc/membersprotectionsenhancements/connectors/NpsConnector.scala
+++ b/app/uk/gov/hmrc/membersprotectionsenhancements/connectors/NpsConnector.scala
@@ -34,7 +34,7 @@ import javax.inject.{Inject, Singleton}
 import java.net.URI
 
 @Singleton
-class NpsConnector @Inject() (val config: AppConfig, val http: HttpClientV2) extends HttpResponseHelper {
+class NpsConnector @Inject()(val config: AppConfig, val http: HttpClientV2) extends HttpResponseHelper {
   protected val classLoggingContext: String = "NpsConnector"
 
   def matchPerson(request: PensionSchemeMemberRequest)

--- a/app/uk/gov/hmrc/membersprotectionsenhancements/connectors/NpsConnector.scala
+++ b/app/uk/gov/hmrc/membersprotectionsenhancements/connectors/NpsConnector.scala
@@ -22,7 +22,7 @@ import uk.gov.hmrc.membersprotectionsenhancements.config.AppConfig
 import uk.gov.hmrc.http.client.HttpClientV2
 import uk.gov.hmrc.membersprotectionsenhancements.models.response.{MatchPersonResponse, ProtectionRecordDetails}
 import uk.gov.hmrc.membersprotectionsenhancements.utils.HttpResponseHelper
-import uk.gov.hmrc.membersprotectionsenhancements.models.errors.MpeError
+import uk.gov.hmrc.membersprotectionsenhancements.models.errors.{MatchPerson, MpeError, RetrieveMpe}
 import uk.gov.hmrc.http._
 import uk.gov.hmrc.membersprotectionsenhancements.controllers.requests.PensionSchemeMemberRequest
 import uk.gov.hmrc.membersprotectionsenhancements.controllers.requests.PensionSchemeMemberRequest.matchPersonWrites
@@ -58,7 +58,7 @@ class NpsConnector @Inject() (val config: AppConfig, val http: HttpClientV2) ext
         logger.warn(
           s"$fullContext - Request to check for a matching individual failed with error code: ${err.code}"
         )
-        err
+        err.copy(source = MatchPerson)
       },
       resp => {
         logger.info(s"$fullContext - Request to check for a matching individual completed successfully")
@@ -90,7 +90,7 @@ class NpsConnector @Inject() (val config: AppConfig, val http: HttpClientV2) ext
         logger.warn(
           s"$fullContext - Request to retrieve protections and enhancements failed with error code: ${err.code}"
         )
-        err
+        err.copy(source = RetrieveMpe)
       },
       resp => {
         logger.info(s"$fullContext - Request to retrieve protections and enhancements completed successfully")

--- a/app/uk/gov/hmrc/membersprotectionsenhancements/connectors/package.scala
+++ b/app/uk/gov/hmrc/membersprotectionsenhancements/connectors/package.scala
@@ -1,7 +1,23 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package uk.gov.hmrc.membersprotectionsenhancements
 
-import cats.data.EitherT
 import uk.gov.hmrc.membersprotectionsenhancements.models.errors.MpeError
+import cats.data.EitherT
 
 import scala.concurrent.Future
 

--- a/app/uk/gov/hmrc/membersprotectionsenhancements/connectors/package.scala
+++ b/app/uk/gov/hmrc/membersprotectionsenhancements/connectors/package.scala
@@ -1,0 +1,10 @@
+package uk.gov.hmrc.membersprotectionsenhancements
+
+import cats.data.EitherT
+import uk.gov.hmrc.membersprotectionsenhancements.models.errors.MpeError
+
+import scala.concurrent.Future
+
+package object connectors {
+  type ConnectorResult[Resp] = EitherT[Future, MpeError, Resp]
+}

--- a/app/uk/gov/hmrc/membersprotectionsenhancements/controllers/MembersLookUpController.scala
+++ b/app/uk/gov/hmrc/membersprotectionsenhancements/controllers/MembersLookUpController.scala
@@ -32,15 +32,12 @@ import scala.concurrent.{ExecutionContext, Future}
 import javax.inject.{Inject, Singleton}
 
 @Singleton
-class MembersLookUpController @Inject() (
-  cc: ControllerComponents,
-  identify: IdentifierAction,
-  getData: DataRetrievalAction,
-  orchestrator: MembersLookUpOrchestrator,
-  validator: MembersLookUpValidator
-)(implicit ec: ExecutionContext)
-    extends BackendController(cc)
-    with Logging {
+class MembersLookUpController @Inject()(cc: ControllerComponents,
+                                        identify: IdentifierAction,
+                                        getData: DataRetrievalAction,
+                                        orchestrator: MembersLookUpOrchestrator,
+                                        validator: MembersLookUpValidator)
+                                       (implicit ec: ExecutionContext) extends BackendController(cc) with Logging {
   val classLoggingContext: String = "MembersLookUpController"
 
   def checkAndRetrieve: Action[JsValue] = identify.andThen(getData).async(parse.json) { request =>

--- a/app/uk/gov/hmrc/membersprotectionsenhancements/controllers/requests/PensionSchemeMemberRequest.scala
+++ b/app/uk/gov/hmrc/membersprotectionsenhancements/controllers/requests/PensionSchemeMemberRequest.scala
@@ -16,16 +16,16 @@
 
 package uk.gov.hmrc.membersprotectionsenhancements.controllers.requests
 
-import play.api.libs.functional.syntax.toFunctionalBuilderOps
 import play.api.libs.json._
 import uk.gov.hmrc.membersprotectionsenhancements.utils.MpeReads._
+import play.api.libs.functional.syntax.toFunctionalBuilderOps
 
 import java.time.LocalDate
 
 case class PensionSchemeMemberRequest(firstName: String,
                                       lastName: String,
                                       dateOfBirth: LocalDate,
-                                      nino: String,
+                                      identifier: String,
                                       psaCheckRef: String)
 
 object PensionSchemeMemberRequest {
@@ -35,15 +35,17 @@ object PensionSchemeMemberRequest {
       .orError(JsPath \ "firstName", "Missing or invalid firstName")
       .and((__ \ "lastName").read[String](name).orError(__ \ "lastName", "Missing or invalid lastName"))
       .and((__ \ "dateOfBirth").read[LocalDate](dateReads).orError(__ \ "dateOfBirth", "Missing or invalid dateOfBirth"))
-      .and((__ \ "nino").read[String](nino).orError(__ \ "nino", "Missing or invalid nino"))
+      //TODO: This should probably be 'identifier' and not 'nino' but that would require frontend changes
+      .and((__ \ "nino").read[String](identifier).orError(__ \ "identifier", "Missing or invalid nino"))
       .and((__ \ "psaCheckRef").read[String](psaCheckRef).orError(__ \ "psaCheckRef", "Missing or invalid psaCheckRef"))(
         PensionSchemeMemberRequest.apply _
       )
 
-  val matchPersonWrites: OWrites[PensionSchemeMemberRequest] = (o: PensionSchemeMemberRequest) => Json.obj(
-    "identifier" -> o.nino,
-    "firstForename" -> o.firstName,
-    "surname" -> o.lastName,
-    "dateOfBirth" -> o.dateOfBirth
-  )
+  val matchPersonWrites: OWrites[PensionSchemeMemberRequest] = (o: PensionSchemeMemberRequest) =>
+    Json.obj(
+      "identifier" -> o.identifier,
+      "firstForename" -> o.firstName,
+      "surname" -> o.lastName,
+      "dateOfBirth" -> o.dateOfBirth
+    )
 }

--- a/app/uk/gov/hmrc/membersprotectionsenhancements/controllers/requests/PensionSchemeMemberRequest.scala
+++ b/app/uk/gov/hmrc/membersprotectionsenhancements/controllers/requests/PensionSchemeMemberRequest.scala
@@ -16,19 +16,17 @@
 
 package uk.gov.hmrc.membersprotectionsenhancements.controllers.requests
 
+import play.api.libs.functional.syntax.toFunctionalBuilderOps
 import play.api.libs.json._
 import uk.gov.hmrc.membersprotectionsenhancements.utils.MpeReads._
-import play.api.libs.functional.syntax.toFunctionalBuilderOps
 
 import java.time.LocalDate
 
-case class PensionSchemeMemberRequest(
-  firstName: String,
-  lastName: String,
-  dateOfBirth: LocalDate,
-  nino: String,
-  psaCheckRef: String
-)
+case class PensionSchemeMemberRequest(firstName: String,
+                                      lastName: String,
+                                      dateOfBirth: LocalDate,
+                                      nino: String,
+                                      psaCheckRef: String)
 
 object PensionSchemeMemberRequest {
   implicit val reads: Reads[PensionSchemeMemberRequest] =
@@ -36,15 +34,16 @@ object PensionSchemeMemberRequest {
       .read[String](name)
       .orError(JsPath \ "firstName", "Missing or invalid firstName")
       .and((__ \ "lastName").read[String](name).orError(__ \ "lastName", "Missing or invalid lastName"))
-      .and(
-        (__ \ "dateOfBirth").read[LocalDate](dateReads).orError(__ \ "dateOfBirth", "Missing or invalid dateOfBirth")
-      )
+      .and((__ \ "dateOfBirth").read[LocalDate](dateReads).orError(__ \ "dateOfBirth", "Missing or invalid dateOfBirth"))
       .and((__ \ "nino").read[String](nino).orError(__ \ "nino", "Missing or invalid nino"))
-      .and(
-        (__ \ "psaCheckRef").read[String](psaCheckRef).orError(__ \ "psaCheckRef", "Missing or invalid psaCheckRef")
-      )(
+      .and((__ \ "psaCheckRef").read[String](psaCheckRef).orError(__ \ "psaCheckRef", "Missing or invalid psaCheckRef"))(
         PensionSchemeMemberRequest.apply _
       )
 
-  implicit val writes: OWrites[PensionSchemeMemberRequest] = Json.writes[PensionSchemeMemberRequest]
+  val matchPersonWrites: OWrites[PensionSchemeMemberRequest] = (o: PensionSchemeMemberRequest) => Json.obj(
+    "identifier" -> o.nino,
+    "firstForename" -> o.firstName,
+    "surname" -> o.lastName,
+    "dateOfBirth" -> o.dateOfBirth
+  )
 }

--- a/app/uk/gov/hmrc/membersprotectionsenhancements/controllers/requests/validators/MembersLookUpValidator.scala
+++ b/app/uk/gov/hmrc/membersprotectionsenhancements/controllers/requests/validators/MembersLookUpValidator.scala
@@ -27,7 +27,7 @@ import scala.concurrent.ExecutionContext
 import javax.inject.{Inject, Singleton}
 
 @Singleton
-class MembersLookUpValidator @Inject() ()(implicit val ec: ExecutionContext) extends Logging {
+class MembersLookUpValidator @Inject()(implicit val ec: ExecutionContext) extends Logging {
   val classLoggingContext: String = "MembersLookUpValidator"
 
   def validate(requestBody: JsValue): Either[MpeError, PensionSchemeMemberRequest] = {

--- a/app/uk/gov/hmrc/membersprotectionsenhancements/controllers/requests/validators/MembersLookUpValidator.scala
+++ b/app/uk/gov/hmrc/membersprotectionsenhancements/controllers/requests/validators/MembersLookUpValidator.scala
@@ -28,15 +28,26 @@ import javax.inject.{Inject, Singleton}
 
 @Singleton
 class MembersLookUpValidator @Inject() ()(implicit val ec: ExecutionContext) extends Logging {
+  val classLoggingContext: String = "MembersLookUpValidator"
 
-  def validate(requestBody: JsValue): Either[MpeError, PensionSchemeMemberRequest] =
+  def validate(requestBody: JsValue): Either[MpeError, PensionSchemeMemberRequest] = {
+    val methodLoggingContext: String = "validate"
+    val fullLoggingContext = s"[$classLoggingContext][$methodLoggingContext]"
+
+    logger.info(s"$fullLoggingContext - Attempting to validate supplied request body")
+
     requestBody.validate[PensionSchemeMemberRequest] match {
-      case JsSuccess(value, _) => Right(value)
+      case JsSuccess(value, _) =>
+        logger.info(s"$fullLoggingContext - Request body validation completed successfully")
+        Right(value)
       case JsError(errors) =>
         val r = errors.map {
           case (_: JsPath, Seq(JsonValidationError(Seq(error: String)))) => error
           case _ => "Unknown error"
         }
+
+        logger.error(s"$fullLoggingContext - Request body validation failed with errors: $r")
         Left(MpeError("BAD_REQUEST", "Invalid request data", Some(r.toSeq)))
     }
+  }
 }

--- a/app/uk/gov/hmrc/membersprotectionsenhancements/models/errors/ErrorSource.scala
+++ b/app/uk/gov/hmrc/membersprotectionsenhancements/models/errors/ErrorSource.scala
@@ -1,0 +1,15 @@
+package uk.gov.hmrc.membersprotectionsenhancements.models.errors
+
+import play.api.libs.json.Writes
+import uk.gov.hmrc.membersprotectionsenhancements.utils.enums.Enums
+
+sealed trait ErrorSource
+
+case object MatchPerson extends ErrorSource
+case object RetrieveMpe extends ErrorSource
+case object Internal extends ErrorSource
+
+object ErrorSource {
+  val writes: Writes[ErrorSource] = Enums.writes[ErrorSource]
+  implicit def genericWrites[T <: ErrorSource]: Writes[T] = writes.contramap[T](c => c: ErrorSource)
+}

--- a/app/uk/gov/hmrc/membersprotectionsenhancements/models/errors/ErrorSource.scala
+++ b/app/uk/gov/hmrc/membersprotectionsenhancements/models/errors/ErrorSource.scala
@@ -1,7 +1,23 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package uk.gov.hmrc.membersprotectionsenhancements.models.errors
 
-import play.api.libs.json.Writes
 import uk.gov.hmrc.membersprotectionsenhancements.utils.enums.Enums
+import play.api.libs.json.Writes
 
 sealed trait ErrorSource
 

--- a/app/uk/gov/hmrc/membersprotectionsenhancements/models/errors/MpeError.scala
+++ b/app/uk/gov/hmrc/membersprotectionsenhancements/models/errors/MpeError.scala
@@ -46,8 +46,8 @@ object InternalError
       message = "An internal server error occurred"
     )
 
-object NotFoundError
-    extends MpeError(
-      code = "NOT_FOUND",
-      message = "Matching not found"
-    )
+object UnexpectedStatusError
+  extends MpeError(
+    code = "UNEXPECTED_STATUS_ERROR",
+    message = "An unexpected status code was returned from downstream"
+  )

--- a/app/uk/gov/hmrc/membersprotectionsenhancements/models/errors/MpeError.scala
+++ b/app/uk/gov/hmrc/membersprotectionsenhancements/models/errors/MpeError.scala
@@ -51,3 +51,9 @@ object UnexpectedStatusError
     code = "UNEXPECTED_STATUS_ERROR",
     message = "An unexpected status code was returned from downstream"
   )
+
+object NoMatchError
+  extends MpeError(
+    code = "NO_MATCH_FOUND",
+    message = "NPS has indicated that no match could be found"
+  )

--- a/app/uk/gov/hmrc/membersprotectionsenhancements/models/errors/MpeError.scala
+++ b/app/uk/gov/hmrc/membersprotectionsenhancements/models/errors/MpeError.scala
@@ -18,12 +18,10 @@ package uk.gov.hmrc.membersprotectionsenhancements.models.errors
 
 import play.api.libs.json.{Json, OWrites}
 
-sealed case class MpeError(
-  code: String,
-  message: String,
-  reasons: Option[Seq[String]] = None,
-  source: ErrorSource = Internal
-)
+sealed case class MpeError(code: String,
+                           message: String,
+                           reasons: Option[Seq[String]] = None,
+                           source: ErrorSource = Internal)
 
 object MpeError {
   implicit val writes: OWrites[MpeError] = Json.writes[MpeError]

--- a/app/uk/gov/hmrc/membersprotectionsenhancements/models/errors/MpeError.scala
+++ b/app/uk/gov/hmrc/membersprotectionsenhancements/models/errors/MpeError.scala
@@ -18,7 +18,10 @@ package uk.gov.hmrc.membersprotectionsenhancements.models.errors
 
 import play.api.libs.json.{Json, OWrites}
 
-sealed case class MpeError(code: String, message: String, reasons: Option[Seq[String]] = None)
+sealed case class MpeError(code: String,
+                           message: String,
+                           reasons: Option[Seq[String]] = None,
+                           source: ErrorSource = Internal)
 
 object MpeError {
   implicit val writes: OWrites[MpeError] = Json.writes[MpeError]
@@ -50,10 +53,4 @@ object UnexpectedStatusError
   extends MpeError(
     code = "UNEXPECTED_STATUS_ERROR",
     message = "An unexpected status code was returned from downstream"
-  )
-
-object NoMatchError
-  extends MpeError(
-    code = "NO_MATCH_FOUND",
-    message = "NPS has indicated that no match could be found"
   )

--- a/app/uk/gov/hmrc/membersprotectionsenhancements/models/errors/MpeError.scala
+++ b/app/uk/gov/hmrc/membersprotectionsenhancements/models/errors/MpeError.scala
@@ -18,10 +18,12 @@ package uk.gov.hmrc.membersprotectionsenhancements.models.errors
 
 import play.api.libs.json.{Json, OWrites}
 
-sealed case class MpeError(code: String,
-                           message: String,
-                           reasons: Option[Seq[String]] = None,
-                           source: ErrorSource = Internal)
+sealed case class MpeError(
+  code: String,
+  message: String,
+  reasons: Option[Seq[String]] = None,
+  source: ErrorSource = Internal
+)
 
 object MpeError {
   implicit val writes: OWrites[MpeError] = Json.writes[MpeError]
@@ -50,7 +52,7 @@ object InternalError
     )
 
 object UnexpectedStatusError
-  extends MpeError(
-    code = "UNEXPECTED_STATUS_ERROR",
-    message = "An unexpected status code was returned from downstream"
-  )
+    extends MpeError(
+      code = "UNEXPECTED_STATUS_ERROR",
+      message = "An unexpected status code was returned from downstream"
+    )

--- a/app/uk/gov/hmrc/membersprotectionsenhancements/models/response/MatchAndRetrieveResult.scala
+++ b/app/uk/gov/hmrc/membersprotectionsenhancements/models/response/MatchAndRetrieveResult.scala
@@ -1,0 +1,9 @@
+package uk.gov.hmrc.membersprotectionsenhancements.models.response
+
+import play.api.libs.json.{Json, OWrites}
+
+case class MatchAndRetrieveResult(matchResult: MatchPersonResponse, protectionRecords: Option[Seq[ProtectionRecord]])
+
+object MatchAndRetrieveResult {
+  implicit val writes: OWrites[MatchAndRetrieveResult] = Json.writes[MatchAndRetrieveResult]
+}

--- a/app/uk/gov/hmrc/membersprotectionsenhancements/models/response/MatchAndRetrieveResult.scala
+++ b/app/uk/gov/hmrc/membersprotectionsenhancements/models/response/MatchAndRetrieveResult.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package uk.gov.hmrc.membersprotectionsenhancements.models.response
 
 import play.api.libs.json.{Json, OWrites}

--- a/app/uk/gov/hmrc/membersprotectionsenhancements/models/response/MatchPersonResponse.scala
+++ b/app/uk/gov/hmrc/membersprotectionsenhancements/models/response/MatchPersonResponse.scala
@@ -1,7 +1,23 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package uk.gov.hmrc.membersprotectionsenhancements.models.response
 
-import play.api.libs.json.{Format, Reads, Writes, __}
 import uk.gov.hmrc.membersprotectionsenhancements.utils.enums.Enums
+import play.api.libs.json._
 
 sealed abstract class MatchPersonResponse
 
@@ -13,5 +29,3 @@ object MatchPersonResponse {
   implicit val reads: Reads[MatchPersonResponse] = (__ \ "matchResult").read[MatchPersonResponse](enumFormat)
   implicit def genericWrites[T <: MatchPersonResponse]: Writes[T] = enumFormat.contramap[T](c => c: MatchPersonResponse)
 }
-
-

--- a/app/uk/gov/hmrc/membersprotectionsenhancements/models/response/MatchPersonResponse.scala
+++ b/app/uk/gov/hmrc/membersprotectionsenhancements/models/response/MatchPersonResponse.scala
@@ -1,0 +1,13 @@
+package uk.gov.hmrc.membersprotectionsenhancements.models.response
+
+import play.api.libs.json.{JsPath, Reads}
+import uk.gov.hmrc.membersprotectionsenhancements.utils.MpeReads.matchResult
+
+case class MatchPersonResponse (matchResult: String)
+
+object MatchPersonResponse {
+  implicit val reads: Reads[MatchPersonResponse] =
+    (JsPath \ "matchResult").read[String](matchResult).map(MatchPersonResponse(_))
+}
+
+

--- a/app/uk/gov/hmrc/membersprotectionsenhancements/models/response/MatchPersonResponse.scala
+++ b/app/uk/gov/hmrc/membersprotectionsenhancements/models/response/MatchPersonResponse.scala
@@ -3,11 +3,14 @@ package uk.gov.hmrc.membersprotectionsenhancements.models.response
 import play.api.libs.json.{JsPath, Reads}
 import uk.gov.hmrc.membersprotectionsenhancements.utils.MpeReads.matchResult
 
-case class MatchPersonResponse (matchResult: String)
+sealed abstract class MatchPersonResponse(val value: String)
+
+case object Match extends MatchPersonResponse("MATCH")
+case object NoMatch extends MatchPersonResponse("NO MATCH")
 
 object MatchPersonResponse {
   implicit val reads: Reads[MatchPersonResponse] =
-    (JsPath \ "matchResult").read[String](matchResult).map(MatchPersonResponse(_))
+    (JsPath \ "matchResult").read[String](matchResult).map(str => if(str == "MATCH") Match else NoMatch)
 }
 
 

--- a/app/uk/gov/hmrc/membersprotectionsenhancements/models/response/MatchPersonResponse.scala
+++ b/app/uk/gov/hmrc/membersprotectionsenhancements/models/response/MatchPersonResponse.scala
@@ -25,7 +25,7 @@ case object `MATCH` extends MatchPersonResponse
 case object `NO MATCH` extends MatchPersonResponse
 
 object MatchPersonResponse {
-  val enumFormat: Format[MatchPersonResponse] = Enums.format[MatchPersonResponse]
+  private val enumFormat: Format[MatchPersonResponse] = Enums.format[MatchPersonResponse]
   implicit val reads: Reads[MatchPersonResponse] = (__ \ "matchResult").read[MatchPersonResponse](enumFormat)
   implicit def genericWrites[T <: MatchPersonResponse]: Writes[T] = enumFormat.contramap[T](c => c: MatchPersonResponse)
 }

--- a/app/uk/gov/hmrc/membersprotectionsenhancements/models/response/MatchPersonResponse.scala
+++ b/app/uk/gov/hmrc/membersprotectionsenhancements/models/response/MatchPersonResponse.scala
@@ -1,16 +1,17 @@
 package uk.gov.hmrc.membersprotectionsenhancements.models.response
 
-import play.api.libs.json.{JsPath, Reads}
-import uk.gov.hmrc.membersprotectionsenhancements.utils.MpeReads.matchResult
+import play.api.libs.json.{Format, Reads, Writes, __}
+import uk.gov.hmrc.membersprotectionsenhancements.utils.enums.Enums
 
-sealed abstract class MatchPersonResponse(val value: String)
+sealed abstract class MatchPersonResponse
 
-case object Match extends MatchPersonResponse("MATCH")
-case object NoMatch extends MatchPersonResponse("NO MATCH")
+case object `MATCH` extends MatchPersonResponse
+case object `NO MATCH` extends MatchPersonResponse
 
 object MatchPersonResponse {
-  implicit val reads: Reads[MatchPersonResponse] =
-    (JsPath \ "matchResult").read[String](matchResult).map(str => if(str == "MATCH") Match else NoMatch)
+  val enumFormat: Format[MatchPersonResponse] = Enums.format[MatchPersonResponse]
+  implicit val reads: Reads[MatchPersonResponse] = (__ \ "matchResult").read[MatchPersonResponse](enumFormat)
+  implicit def genericWrites[T <: MatchPersonResponse]: Writes[T] = enumFormat.contramap[T](c => c: MatchPersonResponse)
 }
 
 

--- a/app/uk/gov/hmrc/membersprotectionsenhancements/models/response/ProtectionRecord.scala
+++ b/app/uk/gov/hmrc/membersprotectionsenhancements/models/response/ProtectionRecord.scala
@@ -18,15 +18,13 @@ package uk.gov.hmrc.membersprotectionsenhancements.models.response
 
 import play.api.libs.json.{Json, OFormat}
 
-case class ProtectionRecord(
-  protectionReference: Option[String],
-  `type`: String,
-  status: String,
-  protectedAmount: Option[Int],
-  lumpSumAmount: Option[Int],
-  lumpSumPercentage: Option[Int],
-  enhancementFactor: Option[Double]
-)
+case class ProtectionRecord(protectionReference: Option[String],
+                            `type`: String,
+                            status: String,
+                            protectedAmount: Option[Int],
+                            lumpSumAmount: Option[Int],
+                            lumpSumPercentage: Option[Int],
+                            enhancementFactor: Option[Double])
 
 object ProtectionRecord {
   implicit val format: OFormat[ProtectionRecord] = Json.format[ProtectionRecord]

--- a/app/uk/gov/hmrc/membersprotectionsenhancements/orchestrators/MembersLookUpOrchestrator.scala
+++ b/app/uk/gov/hmrc/membersprotectionsenhancements/orchestrators/MembersLookUpOrchestrator.scala
@@ -16,46 +16,49 @@
 
 package uk.gov.hmrc.membersprotectionsenhancements.orchestrators
 
-import cats.data.EitherT
 import uk.gov.hmrc.membersprotectionsenhancements.models.errors.MpeError
+import cats.data.EitherT
 import uk.gov.hmrc.membersprotectionsenhancements.connectors.NpsConnector
 import play.api.Logging
 import uk.gov.hmrc.http.HeaderCarrier
 import uk.gov.hmrc.membersprotectionsenhancements.controllers.requests.PensionSchemeMemberRequest
-import uk.gov.hmrc.membersprotectionsenhancements.models.response.{MATCH, MatchAndRetrieveResult, `NO MATCH`}
+import uk.gov.hmrc.membersprotectionsenhancements.models.response.{`NO MATCH`, MATCH, MatchAndRetrieveResult}
 
 import scala.concurrent.{ExecutionContext, Future}
+
 import javax.inject.{Inject, Singleton}
 
 @Singleton
-class MembersLookUpOrchestrator @Inject()(npsConnector: NpsConnector)
-                                         (implicit val ec: ExecutionContext) extends Logging {
+class MembersLookUpOrchestrator @Inject() (npsConnector: NpsConnector)(implicit val ec: ExecutionContext)
+    extends Logging {
   val classLoggingContext: String = "MembersLookUpOrchestrator"
 
-  def matchAndRetrieve(request: PensionSchemeMemberRequest)
-                      (implicit hc: HeaderCarrier): EitherT[Future, MpeError, MatchAndRetrieveResult] = {
+  def checkAndRetrieve(
+    request: PensionSchemeMemberRequest
+  )(implicit hc: HeaderCarrier): EitherT[Future, MpeError, MatchAndRetrieveResult] = {
     val methodLoggingContext: String = "checkAndRetrieve"
     val fullLoggingContext: String = s"[$classLoggingContext][$methodLoggingContext]"
 
-    logger.info(s"$fullLoggingContext - Received request to perform match and retrieve for supplied member details")
+    logger.info(s"$fullLoggingContext - Received request to perform check and retrieve for supplied member details")
 
-    val result: EitherT[Future, MpeError, MatchAndRetrieveResult] = npsConnector.matchPerson(request)
+    val result: EitherT[Future, MpeError, MatchAndRetrieveResult] = npsConnector
+      .matchPerson(request)
       .flatMap {
         case MATCH =>
           logger.info(s"$fullLoggingContext - Supplied member details successfully matched. Proceeding to retrieval")
 
-          npsConnector.retrieveMpe(request.nino, request.psaCheckRef).subflatMap(details => {
+          npsConnector.retrieveMpe(request.identifier, request.psaCheckRef).subflatMap { details =>
             logger.info(s"$fullLoggingContext - Successfully retrieved protections and enhancements data")
             Right(MatchAndRetrieveResult(MATCH, Some(details.protectionRecords)))
-          })
+          }
         case `NO MATCH` =>
           logger.warn(s"$fullLoggingContext - No match was found for the supplied member details")
           EitherT.right(Future.successful(MatchAndRetrieveResult(`NO MATCH`, None)))
       }
 
-    result.leftMap(err => {
+    result.leftMap { err =>
       logger.warn(s"$fullLoggingContext - An error occurred with source: ${err.source}")
       err
-    })
+    }
   }
 }

--- a/app/uk/gov/hmrc/membersprotectionsenhancements/orchestrators/MembersLookUpOrchestrator.scala
+++ b/app/uk/gov/hmrc/membersprotectionsenhancements/orchestrators/MembersLookUpOrchestrator.scala
@@ -29,13 +29,12 @@ import scala.concurrent.{ExecutionContext, Future}
 import javax.inject.{Inject, Singleton}
 
 @Singleton
-class MembersLookUpOrchestrator @Inject() (npsConnector: NpsConnector)(implicit val ec: ExecutionContext)
-    extends Logging {
+class MembersLookUpOrchestrator @Inject()(npsConnector: NpsConnector)
+                                         (implicit val ec: ExecutionContext) extends Logging {
   val classLoggingContext: String = "MembersLookUpOrchestrator"
 
-  def checkAndRetrieve(
-    request: PensionSchemeMemberRequest
-  )(implicit hc: HeaderCarrier): EitherT[Future, MpeError, MatchAndRetrieveResult] = {
+  def checkAndRetrieve(request: PensionSchemeMemberRequest)
+                      (implicit hc: HeaderCarrier): EitherT[Future, MpeError, MatchAndRetrieveResult] = {
     val methodLoggingContext: String = "checkAndRetrieve"
     val fullLoggingContext: String = s"[$classLoggingContext][$methodLoggingContext]"
 

--- a/app/uk/gov/hmrc/membersprotectionsenhancements/utils/HeaderKey.scala
+++ b/app/uk/gov/hmrc/membersprotectionsenhancements/utils/HeaderKey.scala
@@ -1,0 +1,6 @@
+package uk.gov.hmrc.membersprotectionsenhancements.utils
+
+object HeaderKey {
+  val correlationIdKey: String = "correlationId"
+  val govUkOriginatorIdKey = "gov-uk-originator-id"
+}

--- a/app/uk/gov/hmrc/membersprotectionsenhancements/utils/HeaderKey.scala
+++ b/app/uk/gov/hmrc/membersprotectionsenhancements/utils/HeaderKey.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package uk.gov.hmrc.membersprotectionsenhancements.utils
 
 object HeaderKey {

--- a/app/uk/gov/hmrc/membersprotectionsenhancements/utils/HttpResponseHelper.scala
+++ b/app/uk/gov/hmrc/membersprotectionsenhancements/utils/HttpResponseHelper.scala
@@ -16,38 +16,120 @@
 
 package uk.gov.hmrc.membersprotectionsenhancements.utils
 
-import uk.gov.hmrc.membersprotectionsenhancements.models.errors.MpeError
+import com.fasterxml.jackson.core.JsonParseException
+import com.fasterxml.jackson.databind.JsonMappingException
+import uk.gov.hmrc.membersprotectionsenhancements.models.errors.{InternalError, MpeError, UnexpectedStatusError}
 import play.api.http.Status._
+import play.api.libs.json.{JsError, JsResultException, JsSuccess, JsValue, Json, Reads}
 import uk.gov.hmrc.http._
 
 trait HttpResponseHelper extends HttpErrorFunctions with Logging {
+  protected val classLoggingContext: String
 
-  implicit val httpResponseReads: HttpReads[HttpResponse] = (method: String, url: String, response: HttpResponse) =>
-    response
+  implicit def httpReads[Resp: Reads]: HttpReads[Either[MpeError, Resp]] =
+    (method: String, url: String, response: HttpResponse) => {
+      val methodLoggingContext: String = "[httpReads]"
+      val logContextString = classLoggingContext + methodLoggingContext
 
-  def handleErrorResponse(httpMethod: String, url: String)(response: HttpResponse): MpeError =
+      logger.info(
+        s"$logContextString - Attempting to read HTTP response for request with method: $method, and url: $url"
+      )
+
+      if (response.status == OK) {
+        logger.info(
+          s"$logContextString - HTTP response contained success status. Attempting to parse response body"
+        )
+        jsonValidation[Resp](response.body)
+      } else {
+        logger.warn(
+          s"$logContextString - HTTP response contained error status: ${response.status}. Attempting to handle error"
+        )
+        Left(
+          handleErrorResponse(httpMethod = method, url = url, response = response)
+        )
+      }
+    }
+
+  protected[utils] def jsonValidation[Resp: Reads](body: String): Either[MpeError, Resp] = {
+    val methodLoggingContext: String = "[jsonValidation]"
+    val logContextString = classLoggingContext + methodLoggingContext
+
+    try {
+      logger.info(s"$logContextString - Attempting to parse response body string to JSON")
+      val responseJson: JsValue = Json.parse(body)
+
+      logger.info(
+        s"$logContextString - Successfully parsed response body string to JSON. Validating against expected format"
+      )
+
+      responseJson.validate[Resp] match {
+        case JsSuccess(value, _) =>
+          logger.info(s"$logContextString - Successfully parsed response body JSON to expected format")
+          Right[MpeError, Resp](value).withLeft
+        case JsError(errors) =>
+          logger.error(
+            message = s"$logContextString - Failed to parse response body JSON to expected format with errors: $errors",
+            error = JsResultException(errors)
+          )
+          Left(InternalError)
+      }
+    } catch {
+      case ex: JsonParseException =>
+        logger.error(
+          message = s"$logContextString - Failed to parse response body string to JSON with error: ${ex.getMessage}",
+          error = ex
+        )
+        Left(InternalError)
+      case ex: JsonMappingException =>
+        logger.error(
+          message = s"$logContextString - Failed to parse response body string to JSON with error: ${ex.getMessage}",
+          error = ex
+        )
+        Left(InternalError)
+    }
+  }
+
+  protected[utils] def handleErrorResponse(httpMethod: String, url: String, response: HttpResponse): MpeError = {
+    val methodLoggingContext: String = "[handleErrorResponse]"
+    val logContextString = classLoggingContext + methodLoggingContext
+
     response.status match {
       case BAD_REQUEST =>
         val message = badRequestMessage(httpMethod, url, response.body)
-        logger.warn(s"[HttpResponseHelper][handleErrorResponse][BAD_REQUEST] - $message")
+        logger.warn(s"$logContextString[BAD_REQUEST] - $message")
         MpeError("BAD_REQUEST", message)
-      case NOT_FOUND =>
-        val message = notFoundMessage(httpMethod, url, response.body)
-        logger.warn(s"[HttpResponseHelper][handleErrorResponse][NOT_FOUND] - $message")
-        MpeError("NOT_FOUND", message)
-      case status if is4xx(status) =>
-        val message = upstreamResponseMessage(httpMethod, url, status, response.body)
-        logger.warn(s"[HttpResponseHelper][handleErrorResponse] - $message")
+      case FORBIDDEN =>
+        val message = upstreamResponseMessage(httpMethod, url, FORBIDDEN, response.body)
+        logger.warn(s"$logContextString - $message")
         MpeError("FORBIDDEN", message)
-      case status if is5xx(status) =>
-        val message = upstreamResponseMessage(httpMethod, url, status, response.body)
-        logger.warn(s"[HttpResponseHelper][handleErrorResponse] - $message")
+      case NOT_FOUND if httpMethod == "GET" =>
+        val message = notFoundMessage(httpMethod, url, response.body)
+        logger.warn(s"$logContextString[NOT_FOUND] - $message")
+        MpeError("NOT_FOUND", message)
+      case UNPROCESSABLE_ENTITY if httpMethod == "GET" =>
+        val message = upstreamResponseMessage(httpMethod, url, UNPROCESSABLE_ENTITY, response.body)
+        logger.warn(s"$logContextString - $message")
+        MpeError("UNPROCESSABLE_ENTITY", message)
+      case INTERNAL_SERVER_ERROR =>
+        val message = upstreamResponseMessage(httpMethod, url, INTERNAL_SERVER_ERROR, response.body)
+        logger.warn(s"$logContextString - $message")
         MpeError("INTERNAL_ERROR", message)
-      case _ =>
-        throw new UnrecognisedHttpResponseException(httpMethod, url, response)
+      case SERVICE_UNAVAILABLE =>
+        val message = upstreamResponseMessage(httpMethod, url, SERVICE_UNAVAILABLE, response.body)
+        logger.warn(s"$logContextString - $message")
+        MpeError("SERVICE_UNAVAILABLE", message)
+      case status =>
+        logger.error(
+          message = s"$logContextString - Received an unexpected error status: $status",
+          error = new UnrecognisedHttpResponseException(httpMethod, url, response)
+        )
+        UnexpectedStatusError
     }
-
+  }
 }
 
-class UnrecognisedHttpResponseException(method: String, url: String, response: HttpResponse)
-    extends Exception(s"$method to $url failed with status ${response.status}. Response body: '${response.body}'")
+class UnrecognisedHttpResponseException(method: String,
+                                        url: String,
+                                        response: HttpResponse) extends Exception(
+  s"$method to $url failed with status ${response.status}. Response body: '${response.body}'"
+)

--- a/app/uk/gov/hmrc/membersprotectionsenhancements/utils/HttpResponseHelper.scala
+++ b/app/uk/gov/hmrc/membersprotectionsenhancements/utils/HttpResponseHelper.scala
@@ -16,11 +16,11 @@
 
 package uk.gov.hmrc.membersprotectionsenhancements.utils
 
-import com.fasterxml.jackson.core.JsonParseException
-import com.fasterxml.jackson.databind.JsonMappingException
 import uk.gov.hmrc.membersprotectionsenhancements.models.errors.{InternalError, MpeError, UnexpectedStatusError}
+import com.fasterxml.jackson.databind.JsonMappingException
+import com.fasterxml.jackson.core.JsonParseException
+import play.api.libs.json._
 import play.api.http.Status._
-import play.api.libs.json.{JsError, JsResultException, JsSuccess, JsValue, Json, Reads}
 import uk.gov.hmrc.http._
 
 trait HttpResponseHelper extends HttpErrorFunctions with Logging {
@@ -128,8 +128,7 @@ trait HttpResponseHelper extends HttpErrorFunctions with Logging {
   }
 }
 
-class UnrecognisedHttpResponseException(method: String,
-                                        url: String,
-                                        response: HttpResponse) extends Exception(
-  s"$method to $url failed with status ${response.status}. Response body: '${response.body}'"
-)
+class UnrecognisedHttpResponseException(method: String, url: String, response: HttpResponse)
+    extends Exception(
+      s"$method to $url failed with status ${response.status}. Response body: '${response.body}'"
+    )

--- a/app/uk/gov/hmrc/membersprotectionsenhancements/utils/HttpResponseHelper.scala
+++ b/app/uk/gov/hmrc/membersprotectionsenhancements/utils/HttpResponseHelper.scala
@@ -128,7 +128,8 @@ trait HttpResponseHelper extends HttpErrorFunctions with Logging {
   }
 }
 
-class UnrecognisedHttpResponseException(method: String, url: String, response: HttpResponse)
-    extends Exception(
-      s"$method to $url failed with status ${response.status}. Response body: '${response.body}'"
-    )
+class UnrecognisedHttpResponseException(method: String,
+                                        url: String,
+                                        response: HttpResponse) extends Exception(
+  s"$method to $url failed with status ${response.status}. Response body: '${response.body}'"
+)

--- a/app/uk/gov/hmrc/membersprotectionsenhancements/utils/MpeReads.scala
+++ b/app/uk/gov/hmrc/membersprotectionsenhancements/utils/MpeReads.scala
@@ -28,27 +28,29 @@ object MpeReads {
 
   def name(implicit reads: Reads[String]): Reads[String] =
     pattern(
-      """^[a-zA-Z\-' ]{1,35}+$""".r,
-      "error.name"
+      regex = """^[a-zA-Z\-' ]{1,35}+$""".r,
+      error = "error.name"
     )
 
-  def nino(implicit reads: Reads[String]): Reads[String] =
+  def identifier(implicit reads: Reads[String]): Reads[String] =
     pattern(
-      ("^((([ACEHJLMOPRSWXY][A-CEGHJ-NPR-TW-Z]|B[A-CEHJ-NPR-TW-Z]|G[ACEGHJ-NPR-TW-Z]|[KT]" +
-        "[A-CEGHJ-MPR-TW-Z]|N[A-CEGHJL-NPR-SW-Z]|Z[A-CEGHJ-NPR-TW-Y])[0-9]{6})[A-D]?|([0-9]{2}[A-Z]{1}[0-9]{5}))$").r,
-      "error.nino"
+      regex = (
+        "^((([ACEHJLMOPRSWXY][A-CEGHJ-NPR-TW-Z]|B[A-CEHJ-NPR-TW-Z]|G[ACEGHJ-NPR-TW-Z]|[KT]" +
+          "[A-CEGHJ-MPR-TW-Z]|N[A-CEGHJL-NPR-SW-Z]|Z[A-CEGHJ-NPR-TW-Y])[0-9]{6})[A-D]?|([0-9]{2}[A-Z]{1}[0-9]{5}))$"
+      ).r,
+      error = "error.identifier"
     )
 
   def psaCheckRef(implicit reads: Reads[String]): Reads[String] =
     pattern(
-      """^PSA[0-9]{8}[A-Z]$""".r,
-      "error.psaCheckRef"
+      regex = """^PSA[0-9]{8}[A-Z]$""".r,
+      error = "error.psaCheckRef"
     )
 
   def matchResult(implicit reads: Reads[String]): Reads[String] =
     pattern(
-      "^(MATCH|NO MATCH)$".r,
-      "error.matchResult"
+      regex = "^(MATCH|NO MATCH)$".r,
+      error = "error.matchResult"
     )
 
   private val datePattern = DateTimeFormatter.ofPattern("yyyy-MM-dd")

--- a/app/uk/gov/hmrc/membersprotectionsenhancements/utils/MpeReads.scala
+++ b/app/uk/gov/hmrc/membersprotectionsenhancements/utils/MpeReads.scala
@@ -31,16 +31,24 @@ object MpeReads {
       """^[a-zA-Z\-' ]{1,35}+$""".r,
       "error.name"
     )
+
   def nino(implicit reads: Reads[String]): Reads[String] =
     pattern(
       ("^((([ACEHJLMOPRSWXY][A-CEGHJ-NPR-TW-Z]|B[A-CEHJ-NPR-TW-Z]|G[ACEGHJ-NPR-TW-Z]|[KT]" +
         "[A-CEGHJ-MPR-TW-Z]|N[A-CEGHJL-NPR-SW-Z]|Z[A-CEGHJ-NPR-TW-Y])[0-9]{6})[A-D]?|([0-9]{2}[A-Z]{1}[0-9]{5}))$").r,
       "error.nino"
     )
+
   def psaCheckRef(implicit reads: Reads[String]): Reads[String] =
     pattern(
       """^PSA[0-9]{8}[A-Z]$""".r,
       "error.psaCheckRef"
+    )
+
+  def matchResult(implicit reads: Reads[String]): Reads[String] =
+    pattern(
+      "^(MATCH|NO MATCH)$".r,
+      "error.matchResult"
     )
 
   private val datePattern = DateTimeFormatter.ofPattern("yyyy-MM-dd")
@@ -50,6 +58,6 @@ object MpeReads {
 
   implicit class ReadsWithError[T](reads: Reads[T]) {
     def orError(jsPath: JsPath, msg: String): Reads[T] =
-      reads.orElse((json: JsValue) => JsError(jsPath, msg))
+      reads.orElse((_: JsValue) => JsError(jsPath, msg))
   }
 }

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -84,8 +84,9 @@ microservice {
 }
 
 urls {
-    match = "mpe-nps-stub/match"
-    retrieve = "mpe-nps-stub/paye/lifetime-allowance/person"
+    npsContext = "mpe-nps-stub/"
+    match = "paye/individual/match"
+    retrieve = "paye/lifetime-allowance/person"
 }
 
 features {
@@ -95,6 +96,11 @@ features {
     status = ALPHA
   }
   testOnlyOasEnabled = false
+}
+
+govUkOriginatorId {
+    matchPerson = "dummyId"
+    retrieveMpe = "dummyId"
 }
 
 host = "http://localhost:30030"

--- a/test/base/UnitBaseSpec.scala
+++ b/test/base/UnitBaseSpec.scala
@@ -45,9 +45,9 @@ import play.api.test.Helpers.running
 import org.scalatest.freespec.AnyFreeSpec
 import org.scalatest.{BeforeAndAfterEach, OptionValues, TryValues}
 import play.api.Application
+import play.api.libs.json.{JsResult, JsString, JsSuccess, Reads}
 
 import scala.reflect.ClassTag
-
 import java.net.URLEncoder
 
 trait UnitBaseSpec

--- a/test/base/UnitBaseSpec.scala
+++ b/test/base/UnitBaseSpec.scala
@@ -45,9 +45,9 @@ import play.api.test.Helpers.running
 import org.scalatest.freespec.AnyFreeSpec
 import org.scalatest.{BeforeAndAfterEach, OptionValues, TryValues}
 import play.api.Application
-import play.api.libs.json.{JsResult, JsString, JsSuccess, Reads}
 
 import scala.reflect.ClassTag
+
 import java.net.URLEncoder
 
 trait UnitBaseSpec

--- a/test/uk/gov/hmrc/membersprotectionsenhancements/connectors/NpsConnectorSpec.scala
+++ b/test/uk/gov/hmrc/membersprotectionsenhancements/connectors/NpsConnectorSpec.scala
@@ -16,22 +16,23 @@
 
 package uk.gov.hmrc.membersprotectionsenhancements.connectors
 
-import com.github.tomakehurst.wiremock.client.WireMock
 import uk.gov.hmrc.membersprotectionsenhancements.models.errors.MpeError
-import play.api.inject.guice.GuiceApplicationBuilder
 import com.github.tomakehurst.wiremock.client.WireMock._
 import base.ItBaseSpec
-import play.api.Application
-import play.api.http.Status.{BAD_REQUEST, FORBIDDEN, IM_A_TEAPOT, INTERNAL_SERVER_ERROR, NOT_FOUND, SERVICE_UNAVAILABLE, UNPROCESSABLE_ENTITY}
-import play.api.libs.json.JsObject
-import play.api.test.DefaultAwaitTimeout
-import play.api.test.Helpers.await
-import uk.gov.hmrc.http.HeaderCarrier
 import uk.gov.hmrc.membersprotectionsenhancements.controllers.requests.PensionSchemeMemberRequest
-import uk.gov.hmrc.membersprotectionsenhancements.models.response.{MatchPersonResponse, ProtectionRecord, ProtectionRecordDetails, `MATCH`, `NO MATCH`}
+import uk.gov.hmrc.membersprotectionsenhancements.models.response._
+import play.api.test.DefaultAwaitTimeout
+import com.github.tomakehurst.wiremock.client.WireMock
+import play.api.inject.guice.GuiceApplicationBuilder
+import play.api.test.Helpers.await
+import play.api.Application
+import play.api.libs.json.JsObject
+import play.api.http.Status._
+import uk.gov.hmrc.http.HeaderCarrier
+
+import scala.concurrent.ExecutionContext.Implicits.global
 
 import java.time.LocalDate
-import scala.concurrent.ExecutionContext.Implicits.global
 
 class NpsConnectorSpec extends ItBaseSpec with DefaultAwaitTimeout {
 
@@ -59,7 +60,7 @@ class NpsConnectorSpec extends ItBaseSpec with DefaultAwaitTimeout {
         firstName = "Paul",
         lastName = "Smith",
         dateOfBirth = LocalDate.of(2024, 12, 31),
-        nino = "AA123456C",
+        identifier = "AA123456C",
         psaCheckRef = "PSA12345678A"
       )
 
@@ -99,7 +100,7 @@ class NpsConnectorSpec extends ItBaseSpec with DefaultAwaitTimeout {
 
         WireMock.verify(postRequestedFor(urlEqualTo(npsUrl)))
 
-        result mustBe a [Left[_, _]]
+        result mustBe a[Left[_, _]]
         result.swap.getOrElse(MpeError("N/A", "N/A")).code mustBe "UNEXPECTED_STATUS_ERROR"
       }
 
@@ -114,7 +115,7 @@ class NpsConnectorSpec extends ItBaseSpec with DefaultAwaitTimeout {
 
         WireMock.verify(postRequestedFor(urlEqualTo(npsUrl)))
 
-        result mustBe a [Left[_, _]]
+        result mustBe a[Left[_, _]]
         result.swap.getOrElse(MpeError("N/A", "N/A")).code mustBe "INTERNAL_SERVER_ERROR"
       }
 
@@ -135,7 +136,7 @@ class NpsConnectorSpec extends ItBaseSpec with DefaultAwaitTimeout {
 
         WireMock.verify(postRequestedFor(urlEqualTo(npsUrl)))
 
-        result mustBe a [Left[_, _]]
+        result mustBe a[Left[_, _]]
         result.swap.getOrElse(MpeError("N/A", "N/A")).code mustBe "INTERNAL_SERVER_ERROR"
       }
 
@@ -156,7 +157,7 @@ class NpsConnectorSpec extends ItBaseSpec with DefaultAwaitTimeout {
 
         WireMock.verify(postRequestedFor(urlEqualTo(npsUrl)))
 
-        result mustBe a [Right[_, _]]
+        result mustBe a[Right[_, _]]
         result.getOrElse(`NO MATCH`) mustBe `MATCH`
       }
     }
@@ -200,7 +201,7 @@ class NpsConnectorSpec extends ItBaseSpec with DefaultAwaitTimeout {
 
         WireMock.verify(getRequestedFor(urlEqualTo(npsUrl)))
 
-        result mustBe a [Left[_, _]]
+        result mustBe a[Left[_, _]]
         result.swap.getOrElse(MpeError("N/A", "N/A")).code mustBe "UNEXPECTED_STATUS_ERROR"
       }
 
@@ -214,7 +215,7 @@ class NpsConnectorSpec extends ItBaseSpec with DefaultAwaitTimeout {
 
         WireMock.verify(getRequestedFor(urlEqualTo(npsUrl)))
 
-        result mustBe a [Left[_, _]]
+        result mustBe a[Left[_, _]]
         result.swap.getOrElse(MpeError("N/A", "N/A")).code mustBe "INTERNAL_SERVER_ERROR"
       }
 
@@ -244,7 +245,7 @@ class NpsConnectorSpec extends ItBaseSpec with DefaultAwaitTimeout {
 
         WireMock.verify(getRequestedFor(urlEqualTo(npsUrl)))
 
-        result mustBe a [Left[_, _]]
+        result mustBe a[Left[_, _]]
         result.swap.getOrElse(MpeError("N/A", "N/A")).code mustBe "INTERNAL_SERVER_ERROR"
       }
 
@@ -274,7 +275,7 @@ class NpsConnectorSpec extends ItBaseSpec with DefaultAwaitTimeout {
 
         WireMock.verify(getRequestedFor(urlEqualTo(npsUrl)))
 
-        result mustBe a [Right[_, _]]
+        result mustBe a[Right[_, _]]
         result.getOrElse(ProtectionRecordDetails(Nil)).protectionRecords.head mustBe ProtectionRecord(
           protectionReference = Some("some-id"),
           `type` = "some-type",

--- a/test/uk/gov/hmrc/membersprotectionsenhancements/connectors/NpsConnectorSpec.scala
+++ b/test/uk/gov/hmrc/membersprotectionsenhancements/connectors/NpsConnectorSpec.scala
@@ -22,13 +22,13 @@ import play.api.inject.guice.GuiceApplicationBuilder
 import com.github.tomakehurst.wiremock.client.WireMock._
 import base.ItBaseSpec
 import play.api.Application
-import play.api.http.Status.IM_A_TEAPOT
+import play.api.http.Status.{BAD_REQUEST, FORBIDDEN, IM_A_TEAPOT, INTERNAL_SERVER_ERROR, NOT_FOUND, SERVICE_UNAVAILABLE, UNPROCESSABLE_ENTITY}
 import play.api.libs.json.JsObject
 import play.api.test.DefaultAwaitTimeout
 import play.api.test.Helpers.await
 import uk.gov.hmrc.http.HeaderCarrier
 import uk.gov.hmrc.membersprotectionsenhancements.controllers.requests.PensionSchemeMemberRequest
-import uk.gov.hmrc.membersprotectionsenhancements.models.response.{MatchPersonResponse, ProtectionRecord, ProtectionRecordDetails}
+import uk.gov.hmrc.membersprotectionsenhancements.models.response.{MatchPersonResponse, ProtectionRecord, ProtectionRecordDetails, `MATCH`, `NO MATCH`}
 
 import java.time.LocalDate
 import scala.concurrent.ExecutionContext.Implicits.global
@@ -63,20 +63,30 @@ class NpsConnectorSpec extends ItBaseSpec with DefaultAwaitTimeout {
         psaCheckRef = "PSA12345678A"
       )
 
-      "[matchPerson] should return the expected result when NPS returns a recognised error code" in new Test {
-        stubPost(
-          url = npsUrl,
-          requestBody = PensionSchemeMemberRequest.matchPersonWrites.writes(request).toString(),
-          response = badRequest()
-        )
+      def recognisedErrorTest(errorStatus: Int, errorCode: String): Unit =
+        s"[matchPerson] should return the expected result when NPS returns a recognised error with status: $errorStatus" in new Test {
+          stubPost(
+            url = npsUrl,
+            requestBody = PensionSchemeMemberRequest.matchPersonWrites.writes(request).toString(),
+            response = aResponse().withStatus(errorStatus)
+          )
 
-        val result: Either[MpeError, MatchPersonResponse] = await(connector.matchPerson(request).value)
+          val result: Either[MpeError, MatchPersonResponse] = await(connector.matchPerson(request).value)
 
-        WireMock.verify(postRequestedFor(urlEqualTo(npsUrl)))
+          WireMock.verify(postRequestedFor(urlEqualTo(npsUrl)))
 
-        result mustBe a [Left[_, _]]
-        result.swap.getOrElse(MpeError("N/A", "N/A")).code mustBe "BAD_REQUEST"
-      }
+          result mustBe a[Left[_, _]]
+          result.swap.getOrElse(MpeError("N/A", "N/A")).code mustBe errorCode
+        }
+
+      val recognisedErrorScenarios: Map[Int, String] = Map(
+        BAD_REQUEST -> "BAD_REQUEST",
+        FORBIDDEN -> "FORBIDDEN",
+        INTERNAL_SERVER_ERROR -> "INTERNAL_ERROR",
+        SERVICE_UNAVAILABLE -> "SERVICE_UNAVAILABLE"
+      )
+
+      recognisedErrorScenarios.foreach(scenario => recognisedErrorTest(scenario._1, scenario._2))
 
       "[matchPerson] should return the expected result when NPS returns a unrecognised error code" in new Test {
         stubPost(
@@ -147,26 +157,38 @@ class NpsConnectorSpec extends ItBaseSpec with DefaultAwaitTimeout {
         WireMock.verify(postRequestedFor(urlEqualTo(npsUrl)))
 
         result mustBe a [Right[_, _]]
-        result.getOrElse(MatchPersonResponse("N/A")).matchResult mustBe "MATCH"
+        result.getOrElse(`NO MATCH`) mustBe `MATCH`
       }
     }
 
     "retrieveMpe" -> {
       val npsUrl = s"/paye/lifetime-allowance/person/$nino/admin-reference/$psaCheckRef/lookup"
 
-      "[retrieveMpe] should return the expected result when NPS returns a recognised error code" in new Test {
-        stubGet(
-          url = npsUrl,
-          response = badRequest()
-        )
+      def recognisedErrorTest(errorStatus: Int, errorCode: String): Unit =
+        s"[retrieveMpe] should return the expected result when NPS returns a recognised error with status: $errorStatus" in new Test {
+          stubGet(
+            url = npsUrl,
+            response = aResponse().withStatus(errorStatus)
+          )
 
-        val result: Either[MpeError, ProtectionRecordDetails] = await(connector.retrieveMpe(nino, psaCheckRef).value)
+          val result: Either[MpeError, ProtectionRecordDetails] = await(connector.retrieveMpe(nino, psaCheckRef).value)
 
-        WireMock.verify(getRequestedFor(urlEqualTo(npsUrl)))
+          WireMock.verify(getRequestedFor(urlEqualTo(npsUrl)))
 
-        result mustBe a [Left[_, _]]
-        result.swap.getOrElse(MpeError("N/A", "N/A")).code mustBe "BAD_REQUEST"
-      }
+          result mustBe a[Left[_, _]]
+          result.swap.getOrElse(MpeError("N/A", "N/A")).code mustBe errorCode
+        }
+
+      val recognisedErrorScenarios: Map[Int, String] = Map(
+        BAD_REQUEST -> "BAD_REQUEST",
+        FORBIDDEN -> "FORBIDDEN",
+        NOT_FOUND -> "NOT_FOUND",
+        UNPROCESSABLE_ENTITY -> "UNPROCESSABLE_ENTITY",
+        INTERNAL_SERVER_ERROR -> "INTERNAL_ERROR",
+        SERVICE_UNAVAILABLE -> "SERVICE_UNAVAILABLE"
+      )
+
+      recognisedErrorScenarios.foreach(scenario => recognisedErrorTest(scenario._1, scenario._2))
 
       "[retrieveMpe] should return the expected result when NPS returns an unrecognised error code" in new Test {
         stubGet(
@@ -265,127 +287,4 @@ class NpsConnectorSpec extends ItBaseSpec with DefaultAwaitTimeout {
       }
     }
   }
-
-
-/*
-
-  "retrieve" should {
-    "return valid response with status 200 for a valid submission" in {
-
-      val response: String =
-        """
-          |{
-          | "protectionRecords": [
-          |   {
-          |     "protectionReference": "some-id",
-          |     "type": "some-type",
-          |     "status": "some-status",
-          |     "protectedAmount": 1,
-          |     "lumpSumAmount": 1,
-          |     "lumpSumPercentage": 1,
-          |     "enhancementFactor": 0.5
-          |   }
-          | ]
-          |}
-        """.stripMargin
-
-      val resModel: ProtectionRecordDetails = ProtectionRecordDetails(
-        Seq(
-          ProtectionRecord(
-            protectionReference = Some("some-id"),
-            `type` = "some-type",
-            status = "some-status",
-            protectedAmount = Some(1),
-            lumpSumAmount = Some(1),
-            lumpSumPercentage = Some(1),
-            enhancementFactor = Some(0.5)
-          )
-        )
-      )
-
-      stubGet(retrieveUrl, ok(response))
-
-      whenReady(connector.retrieve(nino, psaCheckRef)) { (result: Either[MpeError, ProtectionRecordDetails]) =>
-        WireMock.verify(
-          getRequestedFor(
-            urlEqualTo(retrieveUrl)
-          )
-        )
-        result mustBe Right(resModel)
-      }
-    }
-    "return MpeError wrapped BAD_REQUEST for BAD_REQUEST response" in {
-
-      val errorResponse = MpeError(
-        "BAD_REQUEST",
-        "GET of 'http://localhost:6001/mpe-nps-stub/paye/lifetime-allowance/person/AA123456C/admin-reference/PSA12345678A/lookup' returned 400 (Bad Request). Response body ''",
-        None
-      )
-
-      stubGet(retrieveUrl, badRequest())
-
-      whenReady(connector.retrieve(nino, psaCheckRef)) { (result: Either[MpeError, ProtectionRecordDetails]) =>
-        WireMock.verify(
-          getRequestedFor(
-            urlEqualTo(retrieveUrl)
-          )
-        )
-        result mustBe Left(errorResponse)
-      }
-    }
-
-    "return MpeError wrapped NOT_FOUND for NOT_FOUND response" in {
-
-      val errorResponse = MpeError(
-        "NOT_FOUND",
-        "GET of 'http://localhost:6001/mpe-nps-stub/paye/lifetime-allowance/person/AA123456C/admin-reference/PSA12345678A/lookup' returned 404 (Not Found). Response body: ''"
-      )
-      stubGet(retrieveUrl, notFound())
-
-      whenReady(connector.retrieve(nino, psaCheckRef)) { (result: Either[MpeError, ProtectionRecordDetails]) =>
-        WireMock.verify(
-          getRequestedFor(
-            urlEqualTo(retrieveUrl)
-          )
-        )
-        result mustBe Left(errorResponse)
-      }
-    }
-
-    "return MpeError wrapped FORBIDDEN for any 4xx response" in {
-
-      val errorResponse = MpeError(
-        "FORBIDDEN",
-        "GET of 'http://localhost:6001/mpe-nps-stub/paye/lifetime-allowance/person/AA123456C/admin-reference/PSA12345678A/lookup' returned 403. Response body: ''"
-      )
-      stubGet(retrieveUrl, forbidden())
-
-      whenReady(connector.retrieve(nino, psaCheckRef)) { (result: Either[MpeError, ProtectionRecordDetails]) =>
-        WireMock.verify(
-          getRequestedFor(
-            urlEqualTo(retrieveUrl)
-          )
-        )
-        result mustBe Left(errorResponse)
-      }
-    }
-
-    "return MpeError wrapped INTERNAL_ERROR for any 5xx response" in {
-
-      val errorResponse = MpeError(
-        "INTERNAL_ERROR",
-        "GET of 'http://localhost:6001/mpe-nps-stub/paye/lifetime-allowance/person/AA123456C/admin-reference/PSA12345678A/lookup' returned 500. Response body: ''"
-      )
-      stubGet(retrieveUrl, serverError())
-
-      whenReady(connector.retrieve(nino, psaCheckRef)) { (result: Either[MpeError, ProtectionRecordDetails]) =>
-        WireMock.verify(
-          getRequestedFor(
-            urlEqualTo(retrieveUrl)
-          )
-        )
-        result mustBe Left(errorResponse)
-      }
-    }
-  }*/
 }

--- a/test/uk/gov/hmrc/membersprotectionsenhancements/controllers/MembersLookUpControllerSpec.scala
+++ b/test/uk/gov/hmrc/membersprotectionsenhancements/controllers/MembersLookUpControllerSpec.scala
@@ -17,11 +17,7 @@
 package uk.gov.hmrc.membersprotectionsenhancements.controllers
 
 import play.api.test.FakeRequest
-import uk.gov.hmrc.membersprotectionsenhancements.controllers.actions.{
-  DataRetrievalAction,
-  FakeDataRetrievalAction,
-  IdentifierAction
-}
+import uk.gov.hmrc.membersprotectionsenhancements.controllers.actions._
 import com.github.tomakehurst.wiremock.stubbing.StubMapping
 import play.api.mvc.{AnyContentAsEmpty, Result}
 import play.api.inject.bind
@@ -46,8 +42,11 @@ class MembersLookUpControllerSpec extends ItBaseSpec {
 
   trait Test {
     implicit val hc: HeaderCarrier = HeaderCarrier()
-    val fakeRequest: FakeRequest[AnyContentAsEmpty.type] =
-      FakeRequest("POST", "/members-protections-enhancements/check-and-retrieve")
+
+    val fakeRequest: FakeRequest[AnyContentAsEmpty.type] = FakeRequest(
+      method = "POST",
+      path = "/members-protections-enhancements/check-and-retrieve"
+    )
 
     val nino: String = "AA123456C"
     val psaCheckRef: String = "PSA12345678A"
@@ -141,14 +140,12 @@ class MembersLookUpControllerSpec extends ItBaseSpec {
 
     val controller: MembersLookUpController = application.injector.instanceOf[MembersLookUpController]
 
-    def setupStubs(
-      downstreamRequestBody: String,
-      matchStatus: Int,
-      matchResponse: String,
-      retrieveStatus: Int,
-      retrieveResponse: String,
-      withRetrieveStub: Boolean
-    ): StubMapping = {
+    def setupStubs(downstreamRequestBody: String,
+                   matchStatus: Int,
+                   matchResponse: String,
+                   retrieveStatus: Int,
+                   retrieveResponse: String,
+                   withRetrieveStub: Boolean): StubMapping = {
       def stubMatch: StubMapping = stubPost(
         url = matchUrl,
         requestBody = downstreamRequestBody,

--- a/test/uk/gov/hmrc/membersprotectionsenhancements/models/errors/ErrorSourceSpec.scala
+++ b/test/uk/gov/hmrc/membersprotectionsenhancements/models/errors/ErrorSourceSpec.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package uk.gov.hmrc.membersprotectionsenhancements.models.errors
 
 import base.UnitBaseSpec

--- a/test/uk/gov/hmrc/membersprotectionsenhancements/models/errors/ErrorSourceSpec.scala
+++ b/test/uk/gov/hmrc/membersprotectionsenhancements/models/errors/ErrorSourceSpec.scala
@@ -1,0 +1,14 @@
+package uk.gov.hmrc.membersprotectionsenhancements.models.errors
+
+import base.UnitBaseSpec
+import play.api.libs.json.{JsString, Json}
+
+class ErrorSourceSpec extends UnitBaseSpec {
+  "ErrorSource" -> {
+    "should correctly write any values" in {
+      Json.toJson(MatchPerson) mustBe JsString("MatchPerson")
+      Json.toJson(RetrieveMpe) mustBe JsString("RetrieveMpe")
+      Json.toJson(Internal) mustBe JsString("Internal")
+    }
+  }
+}

--- a/test/uk/gov/hmrc/membersprotectionsenhancements/models/errors/MpeErrorSpec.scala
+++ b/test/uk/gov/hmrc/membersprotectionsenhancements/models/errors/MpeErrorSpec.scala
@@ -1,0 +1,31 @@
+package uk.gov.hmrc.membersprotectionsenhancements.models.errors
+
+import base.UnitBaseSpec
+import play.api.libs.json.Json
+
+class MpeErrorSpec extends UnitBaseSpec {
+  "MpeError" -> {
+    "writes should return the expected JSON" in {
+      MpeError.writes.writes(MpeError("CODE", "Message")) mustBe Json.parse(
+        """
+          |{
+          | "code": "CODE",
+          | "message": "Message"
+          |}
+        """.stripMargin
+      )
+    }
+
+    "genericWrites should return the expected JSON" in {
+      MpeError.genericWrites.writes(InternalError)mustBe Json.parse(
+        """
+          |{
+          | "code": "INTERNAL_SERVER_ERROR",
+          | "message": "An internal server error occurred"
+          |}
+        """.stripMargin
+      )
+    }
+  }
+
+}

--- a/test/uk/gov/hmrc/membersprotectionsenhancements/models/errors/MpeErrorSpec.scala
+++ b/test/uk/gov/hmrc/membersprotectionsenhancements/models/errors/MpeErrorSpec.scala
@@ -6,11 +6,13 @@ import play.api.libs.json.Json
 class MpeErrorSpec extends UnitBaseSpec {
   "MpeError" -> {
     "writes should return the expected JSON" in {
-      MpeError.writes.writes(MpeError("CODE", "Message")) mustBe Json.parse(
+      MpeError.writes.writes(MpeError("CODE", "Message", reasons = Some(Seq("reason")))) mustBe Json.parse(
         """
           |{
           | "code": "CODE",
-          | "message": "Message"
+          | "message": "Message",
+          | "source": "Internal",
+          | "reasons": ["reason"]
           |}
         """.stripMargin
       )
@@ -21,7 +23,8 @@ class MpeErrorSpec extends UnitBaseSpec {
         """
           |{
           | "code": "INTERNAL_SERVER_ERROR",
-          | "message": "An internal server error occurred"
+          | "message": "An internal server error occurred",
+          | "source": "Internal"
           |}
         """.stripMargin
       )

--- a/test/uk/gov/hmrc/membersprotectionsenhancements/models/errors/MpeErrorSpec.scala
+++ b/test/uk/gov/hmrc/membersprotectionsenhancements/models/errors/MpeErrorSpec.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package uk.gov.hmrc.membersprotectionsenhancements.models.errors
 
 import base.UnitBaseSpec
@@ -19,7 +35,7 @@ class MpeErrorSpec extends UnitBaseSpec {
     }
 
     "genericWrites should return the expected JSON" in {
-      MpeError.genericWrites.writes(InternalError)mustBe Json.parse(
+      MpeError.genericWrites.writes(InternalError) mustBe Json.parse(
         """
           |{
           | "code": "INTERNAL_SERVER_ERROR",

--- a/test/uk/gov/hmrc/membersprotectionsenhancements/models/response/MatchAndRetrieveResultSpec.scala
+++ b/test/uk/gov/hmrc/membersprotectionsenhancements/models/response/MatchAndRetrieveResultSpec.scala
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.membersprotectionsenhancements.models.response
+
+import base.UnitBaseSpec
+import play.api.libs.json._
+
+class MatchAndRetrieveResultSpec extends UnitBaseSpec {
+  val testModel: MatchAndRetrieveResult = MatchAndRetrieveResult(
+    matchResult = `MATCH`,
+    protectionRecords = Some(Seq(
+      ProtectionRecord(
+        protectionReference = Some("some-id"),
+        `type` = "some-type",
+        status = "some-status",
+        protectedAmount = Some(1),
+        lumpSumAmount = Some(1),
+        lumpSumPercentage = Some(1),
+        enhancementFactor = Some(0.5)
+      )
+    ))
+  )
+
+  val testJson: JsValue = Json.parse(
+    """
+      |{
+      | "matchResult": "MATCH",
+      | "protectionRecords": [
+      |   {
+      |     "protectionReference": "some-id",
+      |     "type": "some-type",
+      |     "status": "some-status",
+      |     "protectedAmount": 1,
+      |     "lumpSumAmount": 1,
+      |     "lumpSumPercentage": 1,
+      |     "enhancementFactor": 0.5
+      |   }
+      | ]
+      |}
+    """.stripMargin
+  )
+
+  "writes" -> {
+    "should return the expected JSON" in {
+      Json.toJson(testModel) mustBe testJson
+    }
+  }
+}

--- a/test/uk/gov/hmrc/membersprotectionsenhancements/models/response/MatchAndRetrieveResultSpec.scala
+++ b/test/uk/gov/hmrc/membersprotectionsenhancements/models/response/MatchAndRetrieveResultSpec.scala
@@ -22,17 +22,19 @@ import play.api.libs.json._
 class MatchAndRetrieveResultSpec extends UnitBaseSpec {
   val testModel: MatchAndRetrieveResult = MatchAndRetrieveResult(
     matchResult = `MATCH`,
-    protectionRecords = Some(Seq(
-      ProtectionRecord(
-        protectionReference = Some("some-id"),
-        `type` = "some-type",
-        status = "some-status",
-        protectedAmount = Some(1),
-        lumpSumAmount = Some(1),
-        lumpSumPercentage = Some(1),
-        enhancementFactor = Some(0.5)
+    protectionRecords = Some(
+      Seq(
+        ProtectionRecord(
+          protectionReference = Some("some-id"),
+          `type` = "some-type",
+          status = "some-status",
+          protectedAmount = Some(1),
+          lumpSumAmount = Some(1),
+          lumpSumPercentage = Some(1),
+          enhancementFactor = Some(0.5)
+        )
       )
-    ))
+    )
   )
 
   val testJson: JsValue = Json.parse(

--- a/test/uk/gov/hmrc/membersprotectionsenhancements/models/response/MatchPersonResponseSpec.scala
+++ b/test/uk/gov/hmrc/membersprotectionsenhancements/models/response/MatchPersonResponseSpec.scala
@@ -15,7 +15,7 @@ class MatchPersonResponseSpec extends UnitBaseSpec {
 
       val result = Json.parse(json).validate[MatchPersonResponse]
       result mustBe a[JsSuccess[_]]
-      result.get.matchResult mustBe "MATCH"
+      result.get mustBe Match
     }
 
     "[reads] should return the expected object for valid JSON with no match" in {
@@ -28,7 +28,7 @@ class MatchPersonResponseSpec extends UnitBaseSpec {
 
       val result = Json.parse(json).validate[MatchPersonResponse]
       result mustBe a[JsSuccess[_]]
-      result.get.matchResult mustBe "NO MATCH"
+      result.get mustBe NoMatch
     }
 
     "[reads] should return an error for valid JSON which breaks validation rules" in {

--- a/test/uk/gov/hmrc/membersprotectionsenhancements/models/response/MatchPersonResponseSpec.scala
+++ b/test/uk/gov/hmrc/membersprotectionsenhancements/models/response/MatchPersonResponseSpec.scala
@@ -1,0 +1,59 @@
+package uk.gov.hmrc.membersprotectionsenhancements.models.response
+
+import base.UnitBaseSpec
+import play.api.libs.json.{JsError, JsSuccess, Json}
+
+class MatchPersonResponseSpec extends UnitBaseSpec {
+  "MatchPersonResponse" -> {
+    "[reads] should return the expected object for valid JSON" in {
+      val json: String =
+        """
+          |{
+          | "matchResult": "MATCH"
+          |}
+        """.stripMargin
+
+      val result = Json.parse(json).validate[MatchPersonResponse]
+      result mustBe a[JsSuccess[_]]
+      result.get.matchResult mustBe "MATCH"
+    }
+
+    "[reads] should return the expected object for valid JSON with no match" in {
+      val json: String =
+        """
+          |{
+          | "matchResult": "NO MATCH"
+          |}
+        """.stripMargin
+
+      val result = Json.parse(json).validate[MatchPersonResponse]
+      result mustBe a[JsSuccess[_]]
+      result.get.matchResult mustBe "NO MATCH"
+    }
+
+    "[reads] should return an error for valid JSON which breaks validation rules" in {
+      val json: String =
+        """
+          |{
+          | "matchResult": "BEEP"
+          |}
+        """.stripMargin
+
+      val result = Json.parse(json).validate[MatchPersonResponse]
+      result mustBe a[JsError]
+    }
+
+    "[reads] should return an error for invalid JSON" in {
+      val json: String =
+        """
+          |{
+          | "matchResult": 2
+          |}
+        """.stripMargin
+
+      val result = Json.parse(json).validate[MatchPersonResponse]
+      result mustBe a[JsError]
+    }
+  }
+
+}

--- a/test/uk/gov/hmrc/membersprotectionsenhancements/models/response/MatchPersonResponseSpec.scala
+++ b/test/uk/gov/hmrc/membersprotectionsenhancements/models/response/MatchPersonResponseSpec.scala
@@ -1,23 +1,39 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package uk.gov.hmrc.membersprotectionsenhancements.models.response
 
 import base.UnitBaseSpec
-import play.api.libs.json.{JsError, JsString, JsSuccess, Json}
+import play.api.libs.json._
 
 class MatchPersonResponseSpec extends UnitBaseSpec {
   "MatchPersonResponse" -> {
     "reads" -> {
       "[reads] should return the expected object for valid JSON" in {
-      val json: String =
-        """
+        val json: String =
+          """
           |{
           | "matchResult": "MATCH"
           |}
         """.stripMargin
 
-      val result = Json.parse(json).validate[MatchPersonResponse]
-      result mustBe a[JsSuccess[_]]
-      result.get mustBe MATCH
-    }
+        val result = Json.parse(json).validate[MatchPersonResponse]
+        result mustBe a[JsSuccess[_]]
+        result.get mustBe MATCH
+      }
 
       "[reads] should return the expected object for valid JSON with no match" in {
         val json: String =

--- a/test/uk/gov/hmrc/membersprotectionsenhancements/models/response/MatchPersonResponseSpec.scala
+++ b/test/uk/gov/hmrc/membersprotectionsenhancements/models/response/MatchPersonResponseSpec.scala
@@ -1,11 +1,12 @@
 package uk.gov.hmrc.membersprotectionsenhancements.models.response
 
 import base.UnitBaseSpec
-import play.api.libs.json.{JsError, JsSuccess, Json}
+import play.api.libs.json.{JsError, JsString, JsSuccess, Json}
 
 class MatchPersonResponseSpec extends UnitBaseSpec {
   "MatchPersonResponse" -> {
-    "[reads] should return the expected object for valid JSON" in {
+    "reads" -> {
+      "[reads] should return the expected object for valid JSON" in {
       val json: String =
         """
           |{
@@ -15,44 +16,52 @@ class MatchPersonResponseSpec extends UnitBaseSpec {
 
       val result = Json.parse(json).validate[MatchPersonResponse]
       result mustBe a[JsSuccess[_]]
-      result.get mustBe Match
+      result.get mustBe MATCH
     }
 
-    "[reads] should return the expected object for valid JSON with no match" in {
-      val json: String =
-        """
-          |{
-          | "matchResult": "NO MATCH"
-          |}
+      "[reads] should return the expected object for valid JSON with no match" in {
+        val json: String =
+          """
+            |{
+            | "matchResult": "NO MATCH"
+            |}
         """.stripMargin
 
-      val result = Json.parse(json).validate[MatchPersonResponse]
-      result mustBe a[JsSuccess[_]]
-      result.get mustBe NoMatch
+        val result = Json.parse(json).validate[MatchPersonResponse]
+        result mustBe a[JsSuccess[_]]
+        result.get mustBe `NO MATCH`
+      }
+
+      "[reads] should return an error for valid JSON which breaks validation rules" in {
+        val json: String =
+          """
+            |{
+            | "matchResult": "BEEP"
+            |}
+        """.stripMargin
+
+        val result = Json.parse(json).validate[MatchPersonResponse]
+        result mustBe a[JsError]
+      }
+
+      "[reads] should return an error for invalid JSON" in {
+        val json: String =
+          """
+            |{
+            | "matchResult": 2
+            |}
+        """.stripMargin
+
+        val result = Json.parse(json).validate[MatchPersonResponse]
+        result mustBe a[JsError]
+      }
     }
 
-    "[reads] should return an error for valid JSON which breaks validation rules" in {
-      val json: String =
-        """
-          |{
-          | "matchResult": "BEEP"
-          |}
-        """.stripMargin
-
-      val result = Json.parse(json).validate[MatchPersonResponse]
-      result mustBe a[JsError]
-    }
-
-    "[reads] should return an error for invalid JSON" in {
-      val json: String =
-        """
-          |{
-          | "matchResult": 2
-          |}
-        """.stripMargin
-
-      val result = Json.parse(json).validate[MatchPersonResponse]
-      result mustBe a[JsError]
+    "writes" -> {
+      "[writes] should return the expected object" in {
+        Json.toJson(`MATCH`) mustBe JsString("MATCH")
+        Json.toJson(`NO MATCH`) mustBe JsString("NO MATCH")
+      }
     }
   }
 

--- a/test/uk/gov/hmrc/membersprotectionsenhancements/orchestrators/MembersLookUpOrchestratorSpec.scala
+++ b/test/uk/gov/hmrc/membersprotectionsenhancements/orchestrators/MembersLookUpOrchestratorSpec.scala
@@ -16,58 +16,116 @@
 
 package uk.gov.hmrc.membersprotectionsenhancements.orchestrators
 
-import uk.gov.hmrc.membersprotectionsenhancements.models.errors.MpeError
+import uk.gov.hmrc.membersprotectionsenhancements.models.errors._
 import uk.gov.hmrc.http.HeaderCarrier
 import uk.gov.hmrc.membersprotectionsenhancements.controllers.requests.PensionSchemeMemberRequest
-import uk.gov.hmrc.membersprotectionsenhancements.models.response.{ProtectionRecord, ProtectionRecordDetails}
+import uk.gov.hmrc.membersprotectionsenhancements.models.response._
 import play.api.test.Helpers.{await, defaultAwaitTimeout}
 import org.mockito.Mockito.when
 import base.UnitBaseSpec
-import uk.gov.hmrc.membersprotectionsenhancements.connectors.NpsConnector
+import cats.data.EitherT
+import org.mockito.ArgumentMatchers
+import org.mockito.stubbing.OngoingStubbing
+import uk.gov.hmrc.membersprotectionsenhancements.connectors.{ConnectorResult, NpsConnector}
 
-import scala.concurrent.Future
+import scala.concurrent.{Future, TimeoutException}
 import scala.concurrent.ExecutionContext.Implicits.global
-
 import java.time.LocalDate
 
 class MembersLookUpOrchestratorSpec extends UnitBaseSpec {
 
-  val npsConnector: NpsConnector = mock[NpsConnector]
-  val orchestrator = new MembersLookUpOrchestrator(npsConnector)
-  private implicit val headerCarrier: HeaderCarrier = HeaderCarrier()
+  trait Test {
+    val npsConnector: NpsConnector = mock[NpsConnector]
+    val orchestrator: MembersLookUpOrchestrator = new MembersLookUpOrchestrator(npsConnector)
 
-  val request: PensionSchemeMemberRequest =
-    PensionSchemeMemberRequest("Naren", "Vijay", LocalDate.of(2024, 12, 31), "AA123456C", "PSA12345678A")
+    implicit val hc: HeaderCarrier = HeaderCarrier()
 
-  val resModel: ProtectionRecordDetails = ProtectionRecordDetails(
-    Seq(
-      ProtectionRecord(
-        protectionReference = Some("some-id"),
-        `type` = "some-type",
-        status = "some-status",
-        protectedAmount = Some(1),
-        lumpSumAmount = Some(1),
-        lumpSumPercentage = Some(1),
-        enhancementFactor = Some(0.5)
-      )
+    val request: PensionSchemeMemberRequest = PensionSchemeMemberRequest(
+      firstName = "Paul",
+      lastName = "Smith",
+      dateOfBirth = LocalDate.of(2024, 12, 31),
+      nino = "AA123456C",
+      psaCheckRef = "PSA12345678A"
     )
-  )
 
-  "MembersLookUpOrchestrator" - {
-    "return a valid response model for a valid request" in {
+    val retrieveResponse: ProtectionRecord = ProtectionRecord(
+      protectionReference = Some("some-id"),
+      `type` = "some-type",
+      status = "some-status",
+      protectedAmount = Some(1),
+      lumpSumAmount = Some(1),
+      lumpSumPercentage = Some(1),
+      enhancementFactor = Some(0.5)
+    )
 
-      when(npsConnector.retrieve(request.nino, request.psaCheckRef)).thenReturn(Future.successful(Right(resModel)))
-      val result = await(orchestrator.checkAndRetrieve(request))
-      result mustBe Right(resModel)
-    }
+    def matchPersonMock(res: Future[Either[MpeError, MatchPersonResponse]]): OngoingStubbing[ConnectorResult[MatchPersonResponse]] =
+      when(
+        npsConnector.matchPerson(
+          request = ArgumentMatchers.eq(request)
+        )(
+          hc = ArgumentMatchers.any(),
+          ec = ArgumentMatchers.any()
+        )
+      ).thenReturn(EitherT(res))
 
-    "return an error for invalid data" in {
+    def retrieveMpeMock(res: Future[Either[MpeError, ProtectionRecordDetails]]): OngoingStubbing[ConnectorResult[ProtectionRecordDetails]] =
+      when(
+        npsConnector.retrieveMpe(
+          nino = ArgumentMatchers.eq(request.nino),
+          psaCheckRef = ArgumentMatchers.eq(request.psaCheckRef)
+        )(
+          hc = ArgumentMatchers.any(),
+          ec = ArgumentMatchers.any()
+        )
+      ).thenReturn(EitherT(res))
+  }
 
-      val error = MpeError("NOT_FOUND", "No data found")
+  "MembersLookUpOrchestrator" -> {
+    "matchAndRetrieve" -> {
+      "should return the expected result when match person check fails" in new Test {
+        matchPersonMock(Future.successful(Left(InternalError.copy(source = MatchPerson))))
+        val result: Either[MpeError, MatchAndRetrieveResult] = await(orchestrator.matchAndRetrieve(request).value)
 
-      when(npsConnector.retrieve(request.nino, request.psaCheckRef)).thenReturn(Future.successful(Left(error)))
-      val result = await(orchestrator.checkAndRetrieve(request))
-      result mustBe Left(error)
+        result mustBe a[Left[_, _]]
+        result.swap.getOrElse(InvalidBearerTokenError) mustBe InternalError.copy(source = MatchPerson)
+      }
+
+      "should return the expected result when match person check returns NO MATCH" in new Test {
+        matchPersonMock(Future.successful(Right(`NO MATCH`)))
+        val result: Either[MpeError, MatchAndRetrieveResult] = await(orchestrator.matchAndRetrieve(request).value)
+
+        result mustBe a[Right[_, _]]
+        result.getOrElse(MatchAndRetrieveResult(`MATCH`, None)) mustBe MatchAndRetrieveResult(`NO MATCH`, None)
+      }
+
+      "should return the expected result when MPE retrieval fails" in new Test {
+        matchPersonMock(Future.successful(Right(MATCH)))
+        retrieveMpeMock(Future.successful(Left(UnexpectedStatusError)))
+        val result: Either[MpeError, MatchAndRetrieveResult] = await(orchestrator.matchAndRetrieve(request).value)
+
+        result mustBe a[Left[_, _]]
+        result.swap.getOrElse(InvalidBearerTokenError) mustBe UnexpectedStatusError
+      }
+
+      "should return the expected result when both checks succeeds" in new Test {
+        matchPersonMock(Future.successful(Right(MATCH)))
+        retrieveMpeMock(Future.successful(Right(ProtectionRecordDetails(Seq(retrieveResponse)))))
+        val result: Either[MpeError, MatchAndRetrieveResult] = await(orchestrator.matchAndRetrieve(request).value)
+
+        result mustBe a[Right[_, _]]
+        result.getOrElse(MatchAndRetrieveResult(`NO MATCH`, None)) mustBe MatchAndRetrieveResult(
+          matchResult = `MATCH`,
+          protectionRecords = Some(Seq(retrieveResponse))
+        )
+      }
+
+      "should handle appropriately for a fatal error" in new Test {
+        matchPersonMock(Future.successful(Right(MATCH)))
+        retrieveMpeMock(Future.failed(new TimeoutException))
+        lazy val result: Either[MpeError, MatchAndRetrieveResult] = await(orchestrator.matchAndRetrieve(request).value)
+
+        assertThrows[TimeoutException](result)
+      }
     }
   }
 }

--- a/test/uk/gov/hmrc/membersprotectionsenhancements/utils/HttpResponseHelperSpec.scala
+++ b/test/uk/gov/hmrc/membersprotectionsenhancements/utils/HttpResponseHelperSpec.scala
@@ -16,10 +16,10 @@
 
 package uk.gov.hmrc.membersprotectionsenhancements.utils
 
-import base.UnitBaseSpec
 import uk.gov.hmrc.membersprotectionsenhancements.models.errors.{InternalError, MpeError}
-import play.api.http.Status._
+import base.UnitBaseSpec
 import play.api.libs.json.{Json, Reads}
+import play.api.http.Status._
 import uk.gov.hmrc.http._
 
 class HttpResponseHelperSpec extends UnitBaseSpec {
@@ -37,15 +37,12 @@ class HttpResponseHelperSpec extends UnitBaseSpec {
   private val dummyUrl: String = "some-url"
 
   "handleErrorResponse" -> {
-    def handleErrorScenario(status: Int,
-                            method: String,
-                            expectedErrorCode: String): Unit = {
+    def handleErrorScenario(status: Int, method: String, expectedErrorCode: String): Unit =
       s"[handleErrorResponse] should handle appropriately for method: $method, and status: $status" in {
         val dummyResponse = HttpResponse(status, "{}")
         lazy val testResult: MpeError = TestObject.handleErrorResponse(method, dummyUrl, dummyResponse)
         testResult.code mustBe expectedErrorCode
       }
-    }
 
     val testScenarios: Seq[(Int, String, String)] = Seq(
       (BAD_REQUEST, "GET", "BAD_REQUEST"),
@@ -59,9 +56,7 @@ class HttpResponseHelperSpec extends UnitBaseSpec {
       (IM_A_TEAPOT, "GET", "UNEXPECTED_STATUS_ERROR")
     )
 
-    testScenarios.foreach(
-      scenario => handleErrorScenario(scenario._1, scenario._2, scenario._3)
-    )
+    testScenarios.foreach(scenario => handleErrorScenario(scenario._1, scenario._2, scenario._3))
   }
 
   "jsonValidation" -> {
@@ -79,7 +74,7 @@ class HttpResponseHelperSpec extends UnitBaseSpec {
         """.stripMargin
       )
 
-      res mustBe a [Left[_, _]]
+      res mustBe a[Left[_, _]]
       res mustBe Left(InternalError)
     }
 
@@ -99,33 +94,39 @@ class HttpResponseHelperSpec extends UnitBaseSpec {
 
   "httpReads" -> {
     "[httpReads] should return an error for an expected error status" in {
-      val result: Either[MpeError, DummyClass] = TestObject.httpReads[DummyClass].read(
-        method = "GET",
-        url = dummyUrl,
-        response = HttpResponse(BAD_REQUEST, "")
-      )
+      val result: Either[MpeError, DummyClass] = TestObject
+        .httpReads[DummyClass]
+        .read(
+          method = "GET",
+          url = dummyUrl,
+          response = HttpResponse(BAD_REQUEST, "")
+        )
 
       result mustBe a[Left[_, _]]
       result.swap.getOrElse(InternalError).code mustBe "BAD_REQUEST"
     }
 
     "[httpReads] should handle appropriately for an unexpected status code" in {
-      val result: Either[MpeError, DummyClass] = TestObject.httpReads[DummyClass].read(
-        method = "GET",
-        url = dummyUrl,
-        response = HttpResponse(IM_A_TEAPOT, "")
-      )
+      val result: Either[MpeError, DummyClass] = TestObject
+        .httpReads[DummyClass]
+        .read(
+          method = "GET",
+          url = dummyUrl,
+          response = HttpResponse(IM_A_TEAPOT, "")
+        )
 
       result mustBe a[Left[_, _]]
       result.swap.getOrElse(InternalError).code mustBe "UNEXPECTED_STATUS_ERROR"
     }
 
     "[httpReads] should handle appropriately for a success" in {
-      val result: Either[MpeError, DummyClass] = TestObject.httpReads[DummyClass].read(
-        method = "GET",
-        url = dummyUrl,
-        response = HttpResponse(OK, """{"field": "value"}""")
-      )
+      val result: Either[MpeError, DummyClass] = TestObject
+        .httpReads[DummyClass]
+        .read(
+          method = "GET",
+          url = dummyUrl,
+          response = HttpResponse(OK, """{"field": "value"}""")
+        )
 
       result mustBe a[Right[_, _]]
       result.getOrElse(DummyClass("N/A")).field mustBe "value"

--- a/test/uk/gov/hmrc/membersprotectionsenhancements/utils/MpeReadsSpec.scala
+++ b/test/uk/gov/hmrc/membersprotectionsenhancements/utils/MpeReadsSpec.scala
@@ -1,8 +1,24 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package uk.gov.hmrc.membersprotectionsenhancements.utils
 
 import base.UnitBaseSpec
-import MpeReads.{ReadsWithError, dateReads, matchResult, name, nino, psaCheckRef}
-import play.api.libs.json.{JsError, JsNumber, JsPath, JsString, JsSuccess}
+import play.api.libs.json._
+import uk.gov.hmrc.membersprotectionsenhancements.utils.MpeReads._
 
 import java.time.LocalDate
 
@@ -13,17 +29,21 @@ class MpeReadsSpec extends UnitBaseSpec {
     }
 
     "should read an error for a invalid name string" in {
-      name.reads(JsNumber(1)) mustBe a [JsError]
+      name.reads(JsNumber(1)) mustBe a[JsError]
     }
   }
 
-  "nino" -> {
+  "identifier" -> {
     "should read correctly for a valid nino string" in {
-      nino.reads(JsString("AA111111A")) mustBe JsSuccess("AA111111A")
+      identifier.reads(JsString("AA111111A")) mustBe JsSuccess("AA111111A")
+    }
+
+    "should read correctly for a valid TRN string" in {
+      identifier.reads(JsString("99L99999")) mustBe JsSuccess("99L99999")
     }
 
     "should read an error for a invalid nino string" in {
-      nino.reads(JsString("not valid")) mustBe a [JsError]
+      identifier.reads(JsString("not valid")) mustBe a[JsError]
     }
   }
 
@@ -33,7 +53,7 @@ class MpeReadsSpec extends UnitBaseSpec {
     }
 
     "should read an error for a invalid check ref string" in {
-      psaCheckRef.reads(JsString("invalid")) mustBe a [JsError]
+      psaCheckRef.reads(JsString("invalid")) mustBe a[JsError]
     }
   }
 
@@ -43,7 +63,7 @@ class MpeReadsSpec extends UnitBaseSpec {
     }
 
     "should read an error for a invalid match result string" in {
-      matchResult.reads(JsString("invalid")) mustBe a [JsError]
+      matchResult.reads(JsString("invalid")) mustBe a[JsError]
     }
   }
 
@@ -53,7 +73,7 @@ class MpeReadsSpec extends UnitBaseSpec {
     }
 
     "should read an error for a invalid date string" in {
-      dateReads.reads(JsString("")) mustBe a [JsError]
+      dateReads.reads(JsString("")) mustBe a[JsError]
     }
   }
 

--- a/test/uk/gov/hmrc/membersprotectionsenhancements/utils/MpeReadsSpec.scala
+++ b/test/uk/gov/hmrc/membersprotectionsenhancements/utils/MpeReadsSpec.scala
@@ -1,0 +1,66 @@
+package uk.gov.hmrc.membersprotectionsenhancements.utils
+
+import base.UnitBaseSpec
+import MpeReads.{ReadsWithError, dateReads, matchResult, name, nino, psaCheckRef}
+import play.api.libs.json.{JsError, JsNumber, JsPath, JsString, JsSuccess}
+
+import java.time.LocalDate
+
+class MpeReadsSpec extends UnitBaseSpec {
+  "name" -> {
+    "should read correctly for a valid name string" in {
+      name.reads(JsString("Name")) mustBe JsSuccess("Name")
+    }
+
+    "should read an error for a invalid name string" in {
+      name.reads(JsNumber(1)) mustBe a [JsError]
+    }
+  }
+
+  "nino" -> {
+    "should read correctly for a valid nino string" in {
+      nino.reads(JsString("AA111111A")) mustBe JsSuccess("AA111111A")
+    }
+
+    "should read an error for a invalid nino string" in {
+      nino.reads(JsString("not valid")) mustBe a [JsError]
+    }
+  }
+
+  "psaCheckRef" -> {
+    "should read correctly for a valid check ref string" in {
+      psaCheckRef.reads(JsString("PSA11111111A")) mustBe JsSuccess("PSA11111111A")
+    }
+
+    "should read an error for a invalid check ref string" in {
+      psaCheckRef.reads(JsString("invalid")) mustBe a [JsError]
+    }
+  }
+
+  "matchResult" -> {
+    "should read correctly for a valid match result string" in {
+      matchResult.reads(JsString("MATCH")) mustBe JsSuccess("MATCH")
+    }
+
+    "should read an error for a invalid match result string" in {
+      matchResult.reads(JsString("invalid")) mustBe a [JsError]
+    }
+  }
+
+  "dateReads" -> {
+    "should read correctly for a valid date string" in {
+      dateReads.reads(JsString("1990-11-11")) mustBe JsSuccess(LocalDate.of(1990, 11, 11))
+    }
+
+    "should read an error for a invalid date string" in {
+      dateReads.reads(JsString("")) mustBe a [JsError]
+    }
+  }
+
+  "orError" -> {
+    "return the expected error" in {
+      val reads = new ReadsWithError(dateReads).orError(JsPath.apply(Nil), "")
+      reads.reads(JsString("")) mustBe JsError(JsPath.apply(Nil), "")
+    }
+  }
+}


### PR DESCRIPTION
- **LPE-705: Update HTTP parsing to add logging + support for new status codes.**
- **LPE-705: Update HTTP parsing to add logging + support for new status codes.**
- **LPE-705: Add match person data model and tests**
- **LPE-705: Add match person pattern and testing. Add Error writes testing.**
- **LPE-705: Add connector implementation + some refactoring. Add connector tests. Add new config items for NPS auth keys.**
- **LPE-705: Update match person response model to make NO MATCH handling easier**
- **LPE-705: Update orchestrator + add error source field to allow FE to determine which API call causes an error for auditing purposes.**
- **LPE-705: Add controller changes, testing, and copyright headers**
- **LPE-705: Fix weird formatting**
